### PR TITLE
[DOCS] Wrong workflow link for GitHub Actions Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     <a href="https://github.com/geniusyield/atlas/blob/main/LICENSE">
       <img src="https://img.shields.io/github/license/geniusyield/atlas?style=flat-square" />
     </a>
-    <a href="https://github.com/geniusyield/atlas/actions/workflows/haskell.yml">
+    <a href="https://github.com/geniusyield/atlas/actions/workflows/build.yml?query=branch%3Amain">
       <img src="https://img.shields.io/badge/github%20actions-%232671E5.svg?style=flat-square&logo=githubactions&logoColor=white" />
     </a>
     <a href="./CONTRIBUTING.md">


### PR DESCRIPTION
 - Updated the link for the GitHub Actions status badge to be pointing to the build workflow of the main branch.
 
Related to: 
 - #6 