### PR TITLE
Setup and deploy Haddock documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://atlas-app.io">
       <img src="https://img.shields.io/badge/-Documentation-blue?style=flat-square&logo=semantic-scholar&logoColor=white" />
     </a>
-    <a href="TODO">
+    <a href="https://geniusyield.github.io/geniusyield-framework/">
       <img src="https://img.shields.io/badge/-Haddock-5E5184?style=flat-square&logo=haskell&logoColor=white" />
     </a>
     <a href="https://cardano.stackexchange.com/questions/tagged/atlas">
@@ -48,7 +48,7 @@ You can find the complete documentation [here](https://atlas-app.io/).
 
 We welcome the community to help us improve the documentation by opening pull requests in [Atlas Docs](https://github.com/geniusyield/atlas-docs) repository.
 
-To dive deeper into the Atlas implementation, see its [Haddock](TODO).
+To dive deeper into the Atlas implementation, see its [Haddock](https://geniusyield.github.io/geniusyield-framework/).
 
 ## Features
 


### PR DESCRIPTION
This PR implements a temporary solution to fix the broken links that should be in place only until we properly configure the GitHub Pages deployment from the Atlas repository.

Related to:
 - #10 