### PR TITLE
Move haskell-pre-commit-hooks to the Atlas repo#12

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,12 @@
+-   id: hlint-ignore-duplication
+    name: hlint-ignore-duplication
+    description: Runs HLint, but ignores duplications.
+    entry: hlint -i 'Reduce duplication'
+    language: system
+    files: '\.l?hs$'
+-   id: stylish-haskell
+    name: stylish-haskell
+    description: Prettifies Haskell code using stylish-haskell.
+    entry: stylish-haskell --inplace
+    language: system
+    files: '\.l?hs$'


### PR DESCRIPTION
This PR is the first step in moving the pre-commit hooks to the Atlas repo. First we need to move the hook definitions to our repository, then we can change the pre-commit hook configuration to be using the hook definitions from the Atlas repository.

Related to:
 - #12 