### PR TITLE
Remove duplicate cardano-address package from cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -69,14 +69,6 @@ source-repository-package
     lib/wai-middleware-logging
     lib/wallet
 
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-addresses
-    tag: 5094fb9d304ed69adedc99513634a00cbf850fca
-    --sha256: 1zhi8kvr2yhn50dm3dwwb1jlm5yl0y6c6hg39cs6abbxqmsj5jlv
-    subdir: 
-        core
-
 -- Using an in house fork as upstream lacks desired capabilities and uses incompatible dependencies.
 source-repository-package
   type: git


### PR DESCRIPTION
There are two source-repository-package stanzas for cardano-address pointing to the same location. This commit removes the less inclusive of the two.