### PR TITLE
Feat 98: Support to add witness (obtained from `api.signTx`) to original tx cbor

### DIFF
--- a/atlas.cabal
+++ b/atlas.cabal
@@ -156,6 +156,7 @@ library
     , cardano-ledger-alonzo
     , cardano-ledger-byron
     , cardano-ledger-core
+    , cardano-ledger-shelley
     , cardano-slotting
     , cardano-wallet-primitive
     , cardano-addresses

--- a/src/GeniusYield/Types/Tx.hs
+++ b/src/GeniusYield/Types/Tx.hs
@@ -245,7 +245,6 @@ txWitToApi :: GYTxWitness -> Shelley.WitnessSetHKD Identity (Shelley.ShelleyEra 
 txWitToApi = coerce
 
 -- `txWitCbor` is the cbor obtained using CIP-30 compatible wallet's `api.signTx`.
--- >>> let txWitCbor = "a100818258206400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4584048bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801"
 -- >>> txWitToKeyWitnessApi <$> txWitFromHex "a100818258206400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4584048bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801"
 -- Just [ShelleyKeyWitness ShelleyBasedEraBabbage (WitVKey' {wvkKey' = VKey (VerKeyEd25519DSIGN "6400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4"), wvkSig' = SignedDSIGN (SigEd25519DSIGN "48bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801"), wvkKeyHash = KeyHash "f24712bd05f058c6dca5df794f6afbffa8392076e7cb9fda9f508d7a", wvkBytes = "\130X d\NUL\161~\229\140\225*T\198\237\183\185d\240\235!~\NUL\218\199_*G\236\203n\237\208(\t\164X@H\191\162\219\242\NAK\DC4\202\253\DC4%\176\a,g\221\t\204\232/V\136\SYN\156\255Ga\202G\230Usq\236\193\204\186\221\226\&1\222\225y\207\ETB\217\218\194\154a\172d\255\158\242\219\217Ih\236&0\CAN\SOH"})]
 

--- a/src/GeniusYield/Types/Tx.hs
+++ b/src/GeniusYield/Types/Tx.hs
@@ -212,6 +212,7 @@ txIdFromPlutus (Plutus.TxId (Plutus.BuiltinByteString bs)) = txIdFromApi <$> Api
 
 -- | Wrapper around transaction witness set, obtained used CPI-30 compatible wallet's `signTx` method.
 newtype GYTxWitness = GYTxWitness (Shelley.WitnessSetHKD Identity (Shelley.ShelleyEra Crypto.StandardCrypto))  -- Is the choice of `ShelleyEra StandardCrypto` here appropriate? It works nonetheless.
+  deriving newtype Show
 
 instance Swagger.ToSchema GYTxWitness where
     declareNamedSchema _ = pure $ Swagger.named "GYTxWitness" $ mempty
@@ -245,7 +246,12 @@ txWitToApi :: GYTxWitness -> Shelley.WitnessSetHKD Identity (Shelley.ShelleyEra 
 txWitToApi = coerce
 
 -- `txWitCbor` is the cbor obtained using CIP-30 compatible wallet's `api.signTx`.
--- >>> txWitToKeyWitnessApi <$> txWitFromHex "a100818258206400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4584048bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801"
+-- >>> txWitCbor = "a100818258206400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4584048bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801"
+-- >>> txWit = txWitFromHex txWitCbor
+-- >>> show txWit
+-- "Just (WitnessSet' {addrWits' = fromList [WitVKey' {wvkKey' = VKey (VerKeyEd25519DSIGN \"6400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4\"), wvkSig' = SignedDSIGN (SigEd25519DSIGN \"48bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801\"), wvkKeyHash = KeyHash \"f24712bd05f058c6dca5df794f6afbffa8392076e7cb9fda9f508d7a\", wvkBytes = \"\\130X d\\NUL\\161~\\229\\140\\225*T\\198\\237\\183\\185d\\240\\235!~\\NUL\\218\\199_*G\\236\\203n\\237\\208(\\t\\164X@H\\191\\162\\219\\242\\NAK\\DC4\\202\\253\\DC4%\\176\\a,g\\221\\t\\204\\232/V\\136\\SYN\\156\\255Ga\\202G\\230Usq\\236\\193\\204\\186\\221\\226\\&1\\222\\225y\\207\\ETB\\217\\218\\194\\154a\\172d\\255\\158\\242\\219\\217Ih\\236&0\\CAN\\SOH\"}], scriptWits' = fromList [], bootWits' = fromList [], txWitsBytes = \"\\161\\NUL\\129\\130X d\\NUL\\161~\\229\\140\\225*T\\198\\237\\183\\185d\\240\\235!~\\NUL\\218\\199_*G\\236\\203n\\237\\208(\\t\\164X@H\\191\\162\\219\\242\\NAK\\DC4\\202\\253\\DC4%\\176\\a,g\\221\\t\\204\\232/V\\136\\SYN\\156\\255Ga\\202G\\230Usq\\236\\193\\204\\186\\221\\226\\&1\\222\\225y\\207\\ETB\\217\\218\\194\\154a\\172d\\255\\158\\242\\219\\217Ih\\236&0\\CAN\\SOH\"})"
+
+-- >>> txWitToKeyWitnessApi <$> txWit
 -- Just [ShelleyKeyWitness ShelleyBasedEraBabbage (WitVKey' {wvkKey' = VKey (VerKeyEd25519DSIGN "6400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4"), wvkSig' = SignedDSIGN (SigEd25519DSIGN "48bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801"), wvkKeyHash = KeyHash "f24712bd05f058c6dca5df794f6afbffa8392076e7cb9fda9f508d7a", wvkBytes = "\130X d\NUL\161~\229\140\225*T\198\237\183\185d\240\235!~\NUL\218\199_*G\236\203n\237\208(\t\164X@H\191\162\219\242\NAK\DC4\202\253\DC4%\176\a,g\221\t\204\232/V\136\SYN\156\255Ga\202G\230Usq\236\193\204\186\221\226\&1\222\225y\207\ETB\217\218\194\154a\172d\255\158\242\219\217Ih\236&0\CAN\SOH"})]
 
 -- | Obtain `vkeywitness` as cddl calls it to make our unsigned transaction, signed (see `makeSignedTransaction` method).

--- a/src/GeniusYield/Types/Tx.hs
+++ b/src/GeniusYield/Types/Tx.hs
@@ -210,6 +210,7 @@ txIdFromApi = coerce
 txIdFromPlutus :: Plutus.TxId -> Maybe GYTxId
 txIdFromPlutus (Plutus.TxId (Plutus.BuiltinByteString bs)) = txIdFromApi <$> Api.deserialiseFromRawBytes Api.AsTxId bs
 
+-- | Wrapper around transaction witness set, obtained used CPI-30 compatible wallet's `signTx` method.
 newtype GYTxWitness = GYTxWitness (Shelley.WitnessSetHKD Identity (Shelley.ShelleyEra Crypto.StandardCrypto))  -- Is the choice of `ShelleyEra StandardCrypto` here appropriate? It works nonetheless.
 
 instance Swagger.ToSchema GYTxWitness where
@@ -235,7 +236,7 @@ txWitFromHexBS bs = do
   return (GYTxWitness txWit)
 
 txWitFromHex :: String -> Maybe GYTxWitness
-txWitFromHex s = rightToMaybe $ txWitFromHexBS $ BS8.pack s
+txWitFromHex = rightToMaybe . txWitFromHexBS . TE.encodeUtf8 . fromString
 
 txWitFromApi :: Shelley.WitnessSetHKD Identity (Shelley.ShelleyEra Crypto.StandardCrypto) -> GYTxWitness
 txWitFromApi = coerce
@@ -243,9 +244,11 @@ txWitFromApi = coerce
 txWitToApi :: GYTxWitness -> Shelley.WitnessSetHKD Identity (Shelley.ShelleyEra Crypto.StandardCrypto)
 txWitToApi = coerce
 
+-- `txWitCbor` is the cbor obtained using CIP-30 compatible wallet's `api.signTx`.
 -- >>> let txWitCbor = "a100818258206400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4584048bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801"
 -- >>> txWitToKeyWitnessApi <$> txWitFromHex "a100818258206400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4584048bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801"
 -- Just [ShelleyKeyWitness ShelleyBasedEraBabbage (WitVKey' {wvkKey' = VKey (VerKeyEd25519DSIGN "6400a17ee58ce12a54c6edb7b964f0eb217e00dac75f2a47eccb6eedd02809a4"), wvkSig' = SignedDSIGN (SigEd25519DSIGN "48bfa2dbf21514cafd1425b0072c67dd09cce82f5688169cff4761ca47e6557371ecc1ccbadde231dee179cf17d9dac29a61ac64ff9ef2dbd94968ec26301801"), wvkKeyHash = KeyHash "f24712bd05f058c6dca5df794f6afbffa8392076e7cb9fda9f508d7a", wvkBytes = "\130X d\NUL\161~\229\140\225*T\198\237\183\185d\240\235!~\NUL\218\199_*G\236\203n\237\208(\t\164X@H\191\162\219\242\NAK\DC4\202\253\DC4%\176\a,g\221\t\204\232/V\136\SYN\156\255Ga\202G\230Usq\236\193\204\186\221\226\&1\222\225y\207\ETB\217\218\194\154a\172d\255\158\242\219\217Ih\236&0\CAN\SOH"})]
 
+-- | Obtain `vkeywitness` as cddl calls it to make our unsigned transaction, signed (see `makeSignedTransaction` method).
 txWitToKeyWitnessApi :: GYTxWitness -> [Api.S.KeyWitness Api.S.BabbageEra]
 txWitToKeyWitnessApi = fmap (Api.S.ShelleyKeyWitness Api.ShelleyBasedEraBabbage) . Set.toList . Shelley.addrWits . txWitToApi

--- a/src/GeniusYield/Types/TxBody.hs
+++ b/src/GeniusYield/Types/TxBody.hs
@@ -15,6 +15,7 @@ module GeniusYield.Types.TxBody (
     -- * Transaction creation
     signTx,
     unsignedTx,
+    makeSignedTransaction,
     -- * Functions
     txBodyFee,
     txBodyFeeValue,
@@ -37,7 +38,8 @@ import qualified Cardano.Api.Shelley         as Api.S
 import qualified Data.Set                    as Set
 
 import           GeniusYield.Imports
-import           GeniusYield.Types.Key.Class (ToShelleyWitnessSigningKey, toShelleyWitnessSigningKey)
+import           GeniusYield.Types.Key.Class (ToShelleyWitnessSigningKey,
+                                              toShelleyWitnessSigningKey)
 import           GeniusYield.Types.Slot
 import           GeniusYield.Types.Tx
 import           GeniusYield.Types.TxOutRef
@@ -57,6 +59,10 @@ txBodyToApi = coerce
 -- | Sign a transaction body with (potentially) multiple keys.
 signTx :: ToShelleyWitnessSigningKey a =>  GYTxBody -> [a] -> GYTx
 signTx (GYTxBody txBody) skeys = txFromApi $ Api.signShelleyTransaction txBody $ map toShelleyWitnessSigningKey skeys
+
+-- | Make a signed transaction given the transaction body & list of key witnesses
+makeSignedTransaction :: GYTxWitness -> GYTxBody -> GYTx
+makeSignedTransaction txWit (GYTxBody txBody) = txFromApi $ Api.makeSignedTransaction (txWitToKeyWitnessApi txWit) txBody
 
 -- | Create an unsigned transaction from the body.
 unsignedTx :: GYTxBody -> GYTx

--- a/src/GeniusYield/Types/TxBody.hs
+++ b/src/GeniusYield/Types/TxBody.hs
@@ -60,7 +60,7 @@ txBodyToApi = coerce
 signTx :: ToShelleyWitnessSigningKey a =>  GYTxBody -> [a] -> GYTx
 signTx (GYTxBody txBody) skeys = txFromApi $ Api.signShelleyTransaction txBody $ map toShelleyWitnessSigningKey skeys
 
--- | Make a signed transaction given the transaction body & list of key witnesses
+-- | Make a signed transaction given the transaction body & list of key witnesses.
 makeSignedTransaction :: GYTxWitness -> GYTxBody -> GYTx
 makeSignedTransaction txWit (GYTxBody txBody) = txFromApi $ Api.makeSignedTransaction (txWitToKeyWitnessApi txWit) txBody
 


### PR DESCRIPTION
Closed #98 