### PR TITLE
Feat 173: Ensure no indefinite-length terms are present in CBOR encoding of transaction

### DIFF
--- a/src/GeniusYield/Transaction/CBOR.hs
+++ b/src/GeniusYield/Transaction/CBOR.hs
@@ -135,7 +135,7 @@ simplifyTxBodyCbor txBody = do
     makeTermsDefinite (TMapI keyVals) = Just $ TMap keyVals
     makeTermsDefinite _otherwise      = Nothing
 
-{- | This `GYTxBody` doesn't represent @transaction_body@ as mentioned in [CDDL](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/babbage/test-suite/cddl-files/babbage.cddl) specification, it's API's internal type to represent transaction without signing key witnesses. However `GYTx` does represent `transaction` as defined in specification. We therefore obtain `GYTx` and work with it. Here we need an invariant, which is if we receive our simplified `GYTx` transaction, then obtaining `GYTxBody` via `getTxBody` and obtaining `GYTx` back via `unsignedTx` should have the same serialisation.
+{- | This `GYTxBody` doesn't represent @transaction_body@ as mentioned in [CDDL](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/babbage/test-suite/cddl-files/babbage.cddl) specification, it's API's internal type to represent transaction without signing key witnesses. However `GYTx` does represent `transaction` as defined in specification. We therefore obtain `GYTx` and work with it. Here we need an invariant, which is if we receive our simplified `GYTx` transaction, then obtaining `GYTxBody` via `getTxBody` and obtaining `GYTx` back via `unsignedTx` should have the same serialisation for the modifications to CBOR encoding we do here.
 -}
 simplifyGYTxBodyCbor :: GYTxBody -> Either CborSimplificationError GYTxBody
 simplifyGYTxBodyCbor txBody =

--- a/tests/GeniusYield/Test/Providers/Mashup.hs
+++ b/tests/GeniusYield/Test/Providers/Mashup.hs
@@ -71,7 +71,7 @@ providersMashupTests configs =
               valueToSend     = totalSenderFunds `valueMinus` valueFromLovelace 5_000_000
               -- This way, UTxO distribution in test wallet should remain same.
           txBody <- runGYTxMonadNode nid provider [senderAddress] senderAddress Nothing $ pure $ mustHaveOutput $ mkGYTxOutNoDatum @'PlutusV2 senderAddress valueToSend
-          let signedTxBody = signTx txBody [skey]
+          let signedTxBody = signGYTxBody txBody [skey]
           printf "Signed tx: %s\n" (txToHex signedTxBody)
           tid    <- gySubmitTx signedTxBody
           printf "Submitted tx: %s\n" tid


### PR DESCRIPTION
Closes #173.