### PR TITLE
Add some JSON key instances (and swagger paramschema) for `GYMintingPolicyId` and `GYAssetClass`

### DIFF
--- a/src/GeniusYield/Types/Script.hs
+++ b/src/GeniusYield/Types/Script.hs
@@ -306,15 +306,17 @@ instance Web.FromHttpApiData GYMintingPolicyId where
           Left x    -> fail $ "Invalid currency symbol: " ++ show cs ++ "; Reason: " ++ show x
           Right cs' -> return $ mintingPolicyIdFromApi cs'
 
+instance Swagger.ToParamSchema GYMintingPolicyId where
+  toParamSchema _ = mempty
+      & Swagger.type_           ?~ Swagger.SwaggerString
+      & Swagger.format          ?~ "hex"
+      & Swagger.maxLength       ?~ 56
+      & Swagger.minLength       ?~ 56
 
 instance Swagger.ToSchema GYMintingPolicyId where
-  declareNamedSchema _ = pure $ Swagger.named "GYMintingPolicyId" $ mempty
-                       & Swagger.type_           ?~ Swagger.SwaggerString
+  declareNamedSchema _ = pure $ Swagger.named "GYMintingPolicyId" $ Swagger.paramSchemaToSchema (Proxy @GYMintingPolicyId)
                        & Swagger.description     ?~ "This is the hash of a minting policy script."
-                       & Swagger.format          ?~ "hex"
                        & Swagger.example         ?~ toJSON ("ff80aaaf03a273b8f5c558168dc0e2377eea810badbae6eceefc14ef" :: Text)
-                       & Swagger.maxLength       ?~ 56
-                       & Swagger.minLength       ?~ 56
 
 mintingPolicyIdToApi :: GYMintingPolicyId -> Api.PolicyId
 mintingPolicyIdToApi = coerce

--- a/src/GeniusYield/Types/Script.hs
+++ b/src/GeniusYield/Types/Script.hs
@@ -87,6 +87,7 @@ import qualified Cardano.Api                      as Api
 import qualified Cardano.Api.Shelley              as Api.S
 import qualified Codec.Serialise
 import           Control.Lens                     ((?~))
+import           Data.Aeson.Types                 (ToJSONKey (toJSONKey), FromJSONKey (fromJSONKey), FromJSONKeyFunction (FromJSONKeyTextParser), toJSONKeyText)
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import qualified Data.ByteString.Base16           as BS16
 import qualified Data.ByteString.Lazy             as BSL
@@ -276,6 +277,12 @@ readMintingPolicy = coerce readScript
 newtype GYMintingPolicyId = GYMintingPolicyId Api.PolicyId
   deriving stock   (Eq, Ord)
   deriving newtype (ToJSON, FromJSON)
+
+instance ToJSONKey GYMintingPolicyId where
+    toJSONKey = toJSONKeyText mintingPolicyIdToText
+
+instance FromJSONKey GYMintingPolicyId where
+    fromJSONKey = FromJSONKeyTextParser (either fail pure . mintingPolicyIdFromText)
 
 -- |
 --

--- a/src/GeniusYield/Types/Value.hs
+++ b/src/GeniusYield/Types/Value.hs
@@ -413,7 +413,11 @@ isEmptyValue (GYValue m) = Map.null m
 data GYAssetClass = GYLovelace | GYToken GYMintingPolicyId GYTokenName
   deriving stock (Show, Eq, Ord, Generic)
 
-instance Aeson.ToJSONKey GYAssetClass
+instance Aeson.ToJSONKey GYAssetClass where
+    toJSONKey = Aeson.toJSONKeyText Web.toUrlPiece
+
+instance Aeson.FromJSONKey GYAssetClass where
+    fromJSONKey = Aeson.FromJSONKeyTextParser (either (fail . show) pure . Web.parseUrlPiece)
 
 instance Swagger.ToSchema GYAssetClass where
   declareNamedSchema _ = do


### PR DESCRIPTION
Just a few simple instances I'm upstreaming from another project. It's likely that some other types are missing these specific typeclass instances (they are quite useful) but I don't have any off the top of my head right now.