### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         ATLAS_VERSION: ${{needs.build.outputs.ATLAS_VERSION}}
       run: |
         export GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
-        SEMANTIC_VERSION=v${ATLAS_VERSION/#atlas-}
+        SEMANTIC_VERSION=v${ATLAS_VERSION/#atlas-cardano-}
         TAGS=$(git describe --tags)
         GIT_REVISION=$(git rev-parse HEAD)
         CI_BUILD_TIME=$(date --iso-8601=seconds --utc)


### PR DESCRIPTION
## Summary

The atlas semantic version parsing was broken since we renamed the package and added the cardano suffix.

Now with this change the release workflow should be able to parse the semantic version of the atlas package.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
