### PR TITLE
Feat #276: Add support for stake signing keys

### DIFF
--- a/atlas-cardano.cabal
+++ b/atlas-cardano.cabal
@@ -118,6 +118,7 @@ library
     GeniusYield.Types.Logging
     GeniusYield.Types.Natural
     GeniusYield.Types.NetworkId
+    GeniusYield.Types.PaymentKeyHash
     GeniusYield.Types.PlutusVersion
     GeniusYield.Types.Providers
     GeniusYield.Types.PubKeyHash

--- a/src/GeniusYield/Test/Privnet/Examples/Gift.hs
+++ b/src/GeniusYield/Test/Privnet/Examples/Gift.hs
@@ -27,6 +27,7 @@ import           GeniusYield.Imports
 import           GeniusYield.Transaction
 import           GeniusYield.Types
 
+import           Data.Default                     (Default (def))
 import           GeniusYield.Examples.Gift
 import           GeniusYield.Examples.Limbo
 import           GeniusYield.Examples.Treat
@@ -147,7 +148,7 @@ tests setup = testGroup "gift"
         ----------- Create a new user and fund it
         let ironAC = ctxIron ctx
         -- `newUser` just have one UTxO which will be used as collateral.
-        newUser <- newTempUserCtx ctx (ctxUserF ctx) (valueFromLovelace 200_000_000 <> valueSingleton ironAC 25) False
+        newUser <- newTempUserCtx ctx (ctxUserF ctx) (valueFromLovelace 200_000_000 <> valueSingleton ironAC 25) def
         info $ printf "Newly created user's address %s" (show $ userAddr newUser)
         ----------- (ctxUserF ctx) submits some gifts
         txBodyPlace <- ctxRunI ctx (ctxUserF ctx) $ do
@@ -190,7 +191,7 @@ tests setup = testGroup "gift"
         ----------- Create a new user and fund it
         let ironAC = ctxIron ctx
             newUserValue = valueFromLovelace 200_000_000 <> valueSingleton ironAC 25
-        newUser <- newTempUserCtx ctx (ctxUserF ctx) newUserValue True
+        newUser <- newTempUserCtx ctx (ctxUserF ctx) newUserValue (CreateUserConfig { cucGenerateCollateral = True, cucGenerateStakeKey = False })
 
         info $ printf "UTxOs at this new user"
         newUserUtxos <- ctxRunC ctx newUser $ utxosAtAddress (userAddr newUser) Nothing
@@ -208,7 +209,7 @@ tests setup = testGroup "gift"
         ----------- Create a new user and fund it
         pp <- gyGetProtocolParameters (ctxProviders ctx)
         let newUserValue = maximumRequiredCollateralValue pp `valueMinus` valueFromLovelace 1
-        newUser <- newTempUserCtx ctx (ctxUserF ctx) newUserValue False
+        newUser <- newTempUserCtx ctx (ctxUserF ctx) newUserValue def
 
         info $ printf "UTxOs at this new user"
         newUserUtxos <- ctxRunC ctx newUser $ utxosAtAddress (userAddr newUser) Nothing
@@ -219,7 +220,7 @@ tests setup = testGroup "gift"
         pp <- gyGetProtocolParameters (ctxProviders ctx)
         ----------- Create a new user and fund it
         let newUserValue = maximumRequiredCollateralValue pp <> valueFromLovelace 0_500_000
-        newUser <- newTempUserCtx ctx (ctxUserF ctx) newUserValue False
+        newUser <- newTempUserCtx ctx (ctxUserF ctx) newUserValue def
 
         info $ printf "UTxOs at this new user"
         newUserUtxos <- ctxRunC ctx newUser $ utxosAtAddress (userAddr newUser) Nothing
@@ -230,7 +231,7 @@ tests setup = testGroup "gift"
         pp <- gyGetProtocolParameters (ctxProviders ctx)
         ----------- Create a new user and fund it
         let newUserValue = maximumRequiredCollateralValue pp <> valueFromLovelace 1_500_000
-        newUser <- newTempUserCtx ctx (ctxUserF ctx) newUserValue False
+        newUser <- newTempUserCtx ctx (ctxUserF ctx) newUserValue def
 
         info $ printf "UTxOs at this new user"
         newUserUtxos <- ctxRunC ctx newUser $ utxosAtAddress (userAddr newUser) Nothing
@@ -239,7 +240,7 @@ tests setup = testGroup "gift"
 
     , testCaseSteps "Checking if collateral is reserved in case we want it even if it's value is not 5 ada" $ \info -> withSetup setup info $ \ctx -> do
         ----------- Create a new user and fund it
-        newUser <- newTempUserCtx ctx (ctxUserF ctx) (valueFromLovelace 40_000_000) False
+        newUser <- newTempUserCtx ctx (ctxUserF ctx) (valueFromLovelace 40_000_000) def
         -- Add another UTxO to be used as collateral.
         txBody <- ctxRunI ctx (ctxUserF ctx) $ return $ mustHaveOutput $ mkGYTxOutNoDatum (userAddr newUser) (valueFromLovelace 8_000_000)
         void $ submitTx ctx (ctxUserF ctx) txBody

--- a/src/GeniusYield/Test/Privnet/Setup.hs
+++ b/src/GeniusYield/Test/Privnet/Setup.hs
@@ -123,19 +123,20 @@ makeSetup' privnetPath kupoUrl = do
         localGetParams = nodeGetParameters era info
 
     -- context used for tests
-    let ctx0 :: Ctx
+    let user' = flip User Nothing
+        ctx0 :: Ctx
         ctx0 = Ctx
             { ctxEra              = era
             , ctxInfo             = info
             , ctxUserF            = User userFskey Nothing userFaddr
-            , ctxUser2            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @0))
-            , ctxUser3            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @1))
-            , ctxUser4            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @2))
-            , ctxUser5            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @3))
-            , ctxUser6            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @4))
-            , ctxUser7            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @5))
-            , ctxUser8            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @6))
-            , ctxUser9            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @7))
+            , ctxUser2            = uncurry user' (V.index userSkeyAddr (Proxy @0))
+            , ctxUser3            = uncurry user' (V.index userSkeyAddr (Proxy @1))
+            , ctxUser4            = uncurry user' (V.index userSkeyAddr (Proxy @2))
+            , ctxUser5            = uncurry user' (V.index userSkeyAddr (Proxy @3))
+            , ctxUser6            = uncurry user' (V.index userSkeyAddr (Proxy @4))
+            , ctxUser7            = uncurry user' (V.index userSkeyAddr (Proxy @5))
+            , ctxUser8            = uncurry user' (V.index userSkeyAddr (Proxy @6))
+            , ctxUser9            = uncurry user' (V.index userSkeyAddr (Proxy @7))
             , ctxGold             = GYLovelace -- temporarily
             , ctxIron             = GYLovelace -- temporarily
             , ctxLog              = noLogging

--- a/src/GeniusYield/Test/Privnet/Setup.hs
+++ b/src/GeniusYield/Test/Privnet/Setup.hs
@@ -82,7 +82,7 @@ makeSetup' privnetPath kupoUrl = do
     userFskey <- readPaymentSigningKey $ pathUserSKey $ pathUserF paths
     debug $ printf "userFskey = %s\n" (show userFskey)
     debug $ printf "userFvkey = %s\n" (show $ paymentVerificationKey userFskey)
-    debug $ printf "userFpkh  = %s\n" (show $ pubKeyHash $ paymentVerificationKey userFskey)
+    debug $ printf "userFpkh  = %s\n" (show $ paymentKeyHash $ paymentVerificationKey userFskey)
 
     -- Generate user 2 .. 9
     userSkeyAddr <- forM (pathUsers paths) generateUser
@@ -93,7 +93,7 @@ makeSetup' privnetPath kupoUrl = do
         debug $ printf "user addr = %s\n" userIaddr
         debug $ printf "user skey = %s\n" (show userIskey)
         debug $ printf "user vkey = %s\n" (show $ paymentVerificationKey userIskey)
-        debug $ printf "user pkh  = %s\n" (show $ pubKeyHash $ paymentVerificationKey userIskey)
+        debug $ printf "user pkh  = %s\n" (show $ paymentKeyHash $ paymentVerificationKey userIskey)
       ) userSkeyAddr
 
     -- Further down we need local node connection
@@ -127,15 +127,15 @@ makeSetup' privnetPath kupoUrl = do
         ctx0 = Ctx
             { ctxEra              = era
             , ctxInfo             = info
-            , ctxUserF            = User userFskey userFaddr
-            , ctxUser2            = uncurry User (V.index userSkeyAddr (Proxy @0))
-            , ctxUser3            = uncurry User (V.index userSkeyAddr (Proxy @1))
-            , ctxUser4            = uncurry User (V.index userSkeyAddr (Proxy @2))
-            , ctxUser5            = uncurry User (V.index userSkeyAddr (Proxy @3))
-            , ctxUser6            = uncurry User (V.index userSkeyAddr (Proxy @4))
-            , ctxUser7            = uncurry User (V.index userSkeyAddr (Proxy @5))
-            , ctxUser8            = uncurry User (V.index userSkeyAddr (Proxy @6))
-            , ctxUser9            = uncurry User (V.index userSkeyAddr (Proxy @7))
+            , ctxUserF            = User userFskey Nothing userFaddr
+            , ctxUser2            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @0))
+            , ctxUser3            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @1))
+            , ctxUser4            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @2))
+            , ctxUser5            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @3))
+            , ctxUser6            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @4))
+            , ctxUser7            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @5))
+            , ctxUser8            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @6))
+            , ctxUser9            = uncurry (`User` Nothing) (V.index userSkeyAddr (Proxy @7))
             , ctxGold             = GYLovelace -- temporarily
             , ctxIron             = GYLovelace -- temporarily
             , ctxLog              = noLogging

--- a/src/GeniusYield/TxBuilder/Class.hs
+++ b/src/GeniusYield/TxBuilder/Class.hs
@@ -616,8 +616,8 @@ mustMint :: GYMintScript v -> GYRedeemer -> GYTokenName -> Integer -> GYTxSkelet
 mustMint _ _ _ 0  = mempty
 mustMint p r tn n = emptyGYTxSkeleton {gytxMint = Map.singleton p (Map.singleton tn n, r)}
 
-mustBeSignedBy :: GYPubKeyHash -> GYTxSkeleton v
-mustBeSignedBy pkh = emptyGYTxSkeleton {gytxSigs = Set.singleton pkh}
+mustBeSignedBy :: CanSignTx a => a -> GYTxSkeleton v
+mustBeSignedBy pkh = emptyGYTxSkeleton {gytxSigs = Set.singleton $ toPubKeyHash pkh}
 
 isInvalidBefore :: GYSlot -> GYTxSkeleton v
 isInvalidBefore s = emptyGYTxSkeleton {gytxInvalidBefore = Just s}

--- a/src/GeniusYield/TxBuilder/Run.hs
+++ b/src/GeniusYield/TxBuilder/Run.hs
@@ -57,7 +57,8 @@ import qualified PlutusTx.Builtins.Internal                as Plutus
 import qualified Cardano.Simple.PlutusLedgerApi.V1.Scripts as Fork
 import           Data.Sequence                             (ViewR (..), viewr)
 import           GeniusYield.Imports
-import           GeniusYield.Transaction                   (GYCoinSelectionStrategy (GYRandomImproveMultiAsset), BuildTxException (BuildTxBalancingError))
+import           GeniusYield.Transaction                   (BuildTxException (BuildTxBalancingError),
+                                                            GYCoinSelectionStrategy (GYRandomImproveMultiAsset))
 import           GeniusYield.Transaction.Common            (adjustTxOut,
                                                             minimumUTxO)
 import           GeniusYield.TxBuilder.Class
@@ -77,7 +78,7 @@ data Wallet = Wallet
 
 -- | Gets a GYAddress of a testing wallet.
 walletAddress :: Wallet -> GYAddress
-walletAddress Wallet{..} = addressFromPubKeyHash walletNetworkId $ pubKeyHash $
+walletAddress Wallet{..} = addressFromPaymentKeyHash walletNetworkId $ paymentKeyHash $
                            paymentVerificationKey walletPaymentSigningKey
 
 instance HasAddress Wallet where
@@ -120,7 +121,7 @@ asRun g w m = evalRandT (asRandRun w m) g
 ownAddress :: GYTxMonadRun GYAddress
 ownAddress = do
     nid <- networkId
-    asks $ addressFromPubKeyHash nid . pubKeyHash . paymentVerificationKey . walletPaymentSigningKey . runEnvWallet
+    asks $ addressFromPaymentKeyHash nid . paymentKeyHash . paymentVerificationKey . walletPaymentSigningKey . runEnvWallet
 
 liftRun :: Run a -> GYTxMonadRun a
 liftRun = GYTxMonadRun . lift . lift . lift . lift
@@ -296,7 +297,7 @@ sendSkeleton' skeleton ws = do
 
   where
     walletSignatures =
-      let walletPubKeyHash = pubKeyHashToPlutus . pubKeyHash . paymentVerificationKey . walletPaymentSigningKey
+      let walletPubKeyHash = pubKeyHashToPlutus . toPubKeyHash . paymentKeyHash . paymentVerificationKey . walletPaymentSigningKey
           walletKeyPair = paymentSigningKeyToLedgerKeyPair . walletPaymentSigningKey
        in Map.fromList . map (\w -> (walletPubKeyHash w, walletKeyPair w))
 

--- a/src/GeniusYield/Types/Address.hs
+++ b/src/GeniusYield/Types/Address.hs
@@ -17,6 +17,7 @@ module GeniusYield.Types.Address (
     addressToPaymentCredential,
     addressToStakeCredential,
     addressFromPubKeyHash,
+    addressFromPaymentKeyHash,
     addressFromValidator,
     addressFromCredential,
     addressFromValidatorHash,
@@ -91,6 +92,8 @@ import           GeniusYield.Types.Credential         (GYPaymentCredential,
                                                        stakeCredentialToHexText)
 import           GeniusYield.Types.Ledger
 import           GeniusYield.Types.NetworkId
+import           GeniusYield.Types.PaymentKeyHash     (GYPaymentKeyHash,
+                                                       paymentKeyHashToApi)
 import           GeniusYield.Types.PubKeyHash
 import           GeniusYield.Types.Script
 
@@ -243,7 +246,7 @@ addressFromPlutus nid addr =
 -- | If an address is a shelley address, then we'll return payment credential wrapped in `Just`, `Nothing` otherwise.
 --
 -- >>> addressToPaymentCredential addr
--- Just (GYPaymentCredentialByKey (GYPubKeyHash "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"))
+-- Just (GYPaymentCredentialByKey (GYPaymentKeyHash "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"))
 -- >>> addressToPaymentCredential addrScript
 -- Just (GYPaymentCredentialByScript (GYValidatorHash "178155803bc461c5b0b371c779cb481ec7420df0c619cd9860e570d2"))
 -- >>> addressToPaymentCredential addrByron1
@@ -285,10 +288,21 @@ getShelleyAddressStakeCredential (Api.S.ShelleyAddress _network _payment stake) 
 --
 -- /note:/ no stake credential.
 --
+{-# DEPRECATED addressFromPubKeyHash "Use addressFromPaymentKeyHash." #-}
 addressFromPubKeyHash :: GYNetworkId -> GYPubKeyHash -> GYAddress
 addressFromPubKeyHash nid pkh = addressFromApi $ Api.AddressShelley $ Api.S.makeShelleyAddress
     (networkIdToApi nid)
     (Api.S.PaymentCredentialByKey (pubKeyHashToApi pkh))
+    Api.S.NoStakeAddress
+
+-- | Create address from 'GYPaymentKeyHash'.
+--
+-- /note:/ no stake credential.
+--
+addressFromPaymentKeyHash :: GYNetworkId -> GYPaymentKeyHash -> GYAddress
+addressFromPaymentKeyHash nid pkh = addressFromApi $ Api.AddressShelley $ Api.S.makeShelleyAddress
+    (networkIdToApi nid)
+    (Api.S.PaymentCredentialByKey (paymentKeyHashToApi pkh))
     Api.S.NoStakeAddress
 
 -- | Create address from 'GYValidatorHash'.

--- a/src/GeniusYield/Types/Credential.hs
+++ b/src/GeniusYield/Types/Credential.hs
@@ -22,33 +22,33 @@ module GeniusYield.Types.Credential (
   ) where
 
 
-import qualified Cardano.Api                    as Api
-import qualified Cardano.Api.Shelley            as Api
-import           Data.Hashable                  (Hashable (..))
-import           Data.Text                      (Text)
-import           GeniusYield.Types.PubKeyHash   (GYPubKeyHash,
-                                                 pubKeyHashFromApi,
-                                                 pubKeyHashToApi,
-                                                 pubKeyHashToPlutus)
-import           GeniusYield.Types.Script       (GYValidatorHash,
-                                                 validatorHashFromApi,
-                                                 validatorHashToApi,
-                                                 validatorHashToPlutus)
-import           GeniusYield.Types.StakeKeyHash (GYStakeKeyHash,
-                                                 stakeKeyHashFromApi,
-                                                 stakeKeyHashToApi)
-import           GeniusYield.Utils              (serialiseToBech32WithPrefix)
-import qualified PlutusLedgerApi.V1             as Plutus (Credential (..))
-import qualified Text.Printf                    as Printf
+import qualified Cardano.Api                      as Api
+import qualified Cardano.Api.Shelley              as Api
+import           Data.Hashable                    (Hashable (..))
+import           Data.Text                        (Text)
+import           GeniusYield.Types.PaymentKeyHash (GYPaymentKeyHash,
+                                                   paymentKeyHashFromApi,
+                                                   paymentKeyHashToApi,
+                                                   paymentKeyHashToPlutus)
+import           GeniusYield.Types.Script         (GYValidatorHash,
+                                                   validatorHashFromApi,
+                                                   validatorHashToApi,
+                                                   validatorHashToPlutus)
+import           GeniusYield.Types.StakeKeyHash   (GYStakeKeyHash,
+                                                   stakeKeyHashFromApi,
+                                                   stakeKeyHashToApi)
+import           GeniusYield.Utils                (serialiseToBech32WithPrefix)
+import qualified PlutusLedgerApi.V1               as Plutus (Credential (..))
+import qualified Text.Printf                      as Printf
 
 -- | Payment credential.
 data GYPaymentCredential
-       = GYPaymentCredentialByKey !GYPubKeyHash
+       = GYPaymentCredentialByKey !GYPaymentKeyHash
        | GYPaymentCredentialByScript !GYValidatorHash
     deriving (Show, Eq, Ord)
 
 instance Printf.PrintfArg GYPaymentCredential where
-  formatArg (GYPaymentCredentialByKey pkh) = Printf.formatArg $ "Payment key credential: " <> Api.serialiseToRawBytesHexText (pubKeyHashToApi pkh)
+  formatArg (GYPaymentCredentialByKey pkh) = Printf.formatArg $ "Payment key credential: " <> Api.serialiseToRawBytesHexText (paymentKeyHashToApi pkh)
   formatArg (GYPaymentCredentialByScript sh) = Printf.formatArg $ "Payment script credential: " <> Api.serialiseToRawBytesHexText (validatorHashToApi sh)
 
 instance Hashable GYPaymentCredential where
@@ -56,29 +56,29 @@ instance Hashable GYPaymentCredential where
 
 -- | Convert @GY@ type to corresponding type in @cardano-node@ library.
 paymentCredentialToApi :: GYPaymentCredential -> Api.PaymentCredential
-paymentCredentialToApi (GYPaymentCredentialByKey pkh) = Api.PaymentCredentialByKey (pubKeyHashToApi pkh)
+paymentCredentialToApi (GYPaymentCredentialByKey pkh) = Api.PaymentCredentialByKey (paymentKeyHashToApi pkh)
 paymentCredentialToApi (GYPaymentCredentialByScript sh) = Api.PaymentCredentialByScript (validatorHashToApi sh)
 
 -- | Get @GY@ type from corresponding type in @cardano-node@ library.
 paymentCredentialFromApi :: Api.PaymentCredential -> GYPaymentCredential
-paymentCredentialFromApi (Api.PaymentCredentialByKey pkh) = GYPaymentCredentialByKey (pubKeyHashFromApi pkh)
+paymentCredentialFromApi (Api.PaymentCredentialByKey pkh) = GYPaymentCredentialByKey (paymentKeyHashFromApi pkh)
 paymentCredentialFromApi (Api.PaymentCredentialByScript sh) = GYPaymentCredentialByScript (validatorHashFromApi sh)
 
 -- | Convert @GY@ type to corresponding type in @plutus@ library.
 paymentCredentialToPlutus :: GYPaymentCredential -> Plutus.Credential
-paymentCredentialToPlutus (GYPaymentCredentialByKey pkh) = Plutus.PubKeyCredential (pubKeyHashToPlutus pkh)
+paymentCredentialToPlutus (GYPaymentCredentialByKey pkh) = Plutus.PubKeyCredential (paymentKeyHashToPlutus pkh)
 paymentCredentialToPlutus (GYPaymentCredentialByScript sh) = Plutus.ScriptCredential (validatorHashToPlutus sh)
 
 -- | Get hexadecimal value of payment credential.
 paymentCredentialToHexText :: GYPaymentCredential -> Text
 paymentCredentialToHexText =
   \case
-    GYPaymentCredentialByKey pkh -> Api.serialiseToRawBytesHexText (pubKeyHashToApi pkh)
+    GYPaymentCredentialByKey pkh -> Api.serialiseToRawBytesHexText (paymentKeyHashToApi pkh)
     GYPaymentCredentialByScript sh -> Api.serialiseToRawBytesHexText (validatorHashToApi sh)
 
 -- | Get the bech32 encoding for the given credential.
 paymentCredentialToBech32 :: GYPaymentCredential -> Text
-paymentCredentialToBech32 (GYPaymentCredentialByKey pkh) = serialiseToBech32WithPrefix "addr_vkh" $ pubKeyHashToApi pkh
+paymentCredentialToBech32 (GYPaymentCredentialByKey pkh) = serialiseToBech32WithPrefix "addr_vkh" $ paymentKeyHashToApi pkh
 paymentCredentialToBech32 (GYPaymentCredentialByScript sh) = serialiseToBech32WithPrefix "addr_shared_vkh" $ validatorHashToApi sh
 
 -- | Stake credential.

--- a/src/GeniusYield/Types/Key.hs
+++ b/src/GeniusYield/Types/Key.hs
@@ -14,13 +14,14 @@ module GeniusYield.Types.Key
     , paymentVerificationKeyToLedger
     , paymentVerificationKeyRawBytes
     , pubKeyHash
+    , paymentKeyHash
       -- * Payment signing key
     , GYPaymentSigningKey
     , GYExtendedPaymentSigningKey
-    , GYSomeSigningKey (..)
     , paymentSigningKeyFromApi
     , extendedPaymentSigningKeyFromApi
     , paymentSigningKeyToApi
+    , extendedPaymentSigningKeyToApi
     , paymentSigningKeyToLedger
     , paymentSigningKeyToLedgerKeyPair
     , paymentSigningKeyFromLedgerKeyPair
@@ -28,8 +29,28 @@ module GeniusYield.Types.Key
     , readExtendedPaymentSigningKey
     , readSomeSigningKey
     , writePaymentSigningKey
+    , writeExtendedPaymentSigningKey
     , paymentVerificationKey
     , generatePaymentSigningKey
+    -- * Stake verification key
+    , GYStakeVerificationKey
+    , stakeVerificationKeyFromApi
+    , stakeVerificationKeyToApi
+    , stakeKeyHash
+    -- * Stake signing key
+    , GYStakeSigningKey
+    , GYExtendedStakeSigningKey
+    , stakeSigningKeyFromApi
+    , extendedStakeSigningKeyFromApi
+    , stakeSigningKeyToApi
+    , extendedStakeSigningKeyToApi
+    , readStakeSigningKey
+    , readExtendedStakeSigningKey
+    , writeStakeSigningKey
+    , writeExtendedStakeSigningKey
+    , stakeVerificationKey
+    , generateStakeSigningKey
+    , GYSomeSigningKey (..)
 ) where
 
 import qualified Cardano.Api                      as Api
@@ -48,7 +69,12 @@ import qualified Text.Printf                      as Printf
 import           GeniusYield.Imports
 import           GeniusYield.Types.Key.Class      (ToShelleyWitnessSigningKey,
                                                    toShelleyWitnessSigningKey)
-import           GeniusYield.Types.PubKeyHash
+import           GeniusYield.Types.PaymentKeyHash (GYPaymentKeyHash,
+                                                   paymentKeyHashFromApi)
+import           GeniusYield.Types.PubKeyHash     (GYPubKeyHash,
+                                                   pubKeyHashFromApi)
+import           GeniusYield.Types.StakeKeyHash   (GYStakeKeyHash,
+                                                   stakeKeyHashFromApi)
 
 -- $setup
 --
@@ -93,8 +119,12 @@ paymentVerificationKeyToLedger = coerce
 paymentVerificationKeyRawBytes :: GYPaymentVerificationKey -> BS8.ByteString
 paymentVerificationKeyRawBytes = Api.serialiseToRawBytes . paymentVerificationKeyToApi
 
+{-# DEPRECATED pubKeyHash "Use paymentKeyHash." #-}
 pubKeyHash :: GYPaymentVerificationKey -> GYPubKeyHash
 pubKeyHash = pubKeyHashFromApi . Api.verificationKeyHash . paymentVerificationKeyToApi
+
+paymentKeyHash :: GYPaymentVerificationKey -> GYPaymentKeyHash
+paymentKeyHash = paymentKeyHashFromApi . Api.verificationKeyHash . paymentVerificationKeyToApi
 
 -- |
 --
@@ -186,6 +216,9 @@ extendedPaymentSigningKeyFromApi = coerce
 paymentSigningKeyToApi :: GYPaymentSigningKey -> Api.SigningKey Api.PaymentKey
 paymentSigningKeyToApi = coerce
 
+extendedPaymentSigningKeyToApi :: GYExtendedPaymentSigningKey -> Api.SigningKey Api.PaymentExtendedKey
+extendedPaymentSigningKeyToApi = coerce
+
 paymentSigningKeyToLedger :: GYPaymentSigningKey -> Ledger.SignKeyDSIGN Ledger.StandardCrypto
 paymentSigningKeyToLedger = coerce
 
@@ -222,6 +255,15 @@ readExtendedPaymentSigningKey fp = do
 writePaymentSigningKey :: FilePath -> GYPaymentSigningKey -> IO ()
 writePaymentSigningKey file key = do
     e <- Api.writeFileTextEnvelope (Api.File file) (Just "Payment Signing Key") $ paymentSigningKeyToApi key
+    case e of
+        Left (err :: Api.FileError ()) -> throwIO $ userError $ show err
+        Right ()                       -> return ()
+
+-- | Writes a extended payment signing key to a file.
+--
+writeExtendedPaymentSigningKey :: FilePath -> GYExtendedPaymentSigningKey -> IO ()
+writeExtendedPaymentSigningKey file key = do
+    e <- Api.writeFileTextEnvelope (Api.File file) (Just "Extended Payment Signing Key") $ extendedPaymentSigningKeyToApi key
     case e of
         Left (err :: Api.FileError ()) -> throwIO $ userError $ show err
         Right ()                       -> return ()
@@ -281,13 +323,232 @@ instance Printf.PrintfArg GYPaymentSigningKey where
 generatePaymentSigningKey :: IO GYPaymentSigningKey
 generatePaymentSigningKey = paymentSigningKeyFromApi <$> Api.generateSigningKey Api.AsPaymentKey
 
-data GYSomeSigningKey = forall a. ToShelleyWitnessSigningKey a => GYSomeSigningKey a
+
+-------------------------------------------------------------------------------
+-- Stake verification key (public)
+-------------------------------------------------------------------------------
+
+-- |
+--
+-- >>> "0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605" :: GYStakeVerificationKey
+-- GYStakeVerificationKey "0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605"
+--
+newtype GYStakeVerificationKey = GYStakeVerificationKey (Api.VerificationKey Api.StakeKey)
+    deriving stock Show
+    deriving newtype (Eq, IsString)
+
+-- |
+--
+-- >>> stakeVerificationKeyFromApi "0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605"
+-- GYStakeVerificationKey "0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605"
+--
+stakeVerificationKeyFromApi :: Api.VerificationKey Api.StakeKey -> GYStakeVerificationKey
+stakeVerificationKeyFromApi = coerce
+
+-- |
+--
+-- >>> stakeVerificationKeyToApi "0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605"
+-- "0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605"
+--
+stakeVerificationKeyToApi :: GYStakeVerificationKey -> Api.VerificationKey Api.StakeKey
+stakeVerificationKeyToApi = coerce
+
+stakeKeyHash :: GYStakeVerificationKey -> GYStakeKeyHash
+stakeKeyHash = stakeKeyHashFromApi . Api.verificationKeyHash . stakeVerificationKeyToApi
+
+-- |
+--
+-- >>> LBS8.putStrLn $ Aeson.encode ("0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605" :: GYStakeVerificationKey)
+-- "58200717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605"
+--
+instance Aeson.ToJSON GYStakeVerificationKey where
+    toJSON = Aeson.String . TE.decodeUtf8 . BS16.encode . Api.serialiseToCBOR . stakeVerificationKeyToApi
+
+-- |
+--
+-- >>> Aeson.eitherDecode @GYStakeVerificationKey "\"58200717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605\""
+-- Right (GYStakeVerificationKey "0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605")
+--
+-- >>> Aeson.eitherDecode @GYStakeVerificationKey "\"58200717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193zzz\""
+-- Left "Error in $: invalid character at offset: 65"
+--
+instance Aeson.FromJSON GYStakeVerificationKey where
+    parseJSON (Aeson.String t) = case BS16.decode $ BS8.pack $ T.unpack t of
+        Left err -> fail err
+        Right bs -> case Api.deserialiseFromCBOR (Api.AsVerificationKey Api.AsStakeKey) bs of
+            Left err   -> fail $ show err
+            Right skey -> return $ GYStakeVerificationKey skey
+    parseJSON _ = fail "stake verification key expected"
+
+
+
+-- |
+--
+-- >>> Printf.printf "%s\n" ("0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605" :: GYStakeVerificationKey)
+-- 0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605
+--
+instance Printf.PrintfArg GYStakeVerificationKey where
+    formatArg = Printf.formatArg . Api.serialiseToRawBytesHexText . stakeVerificationKeyToApi
+
+
+-------------------------------------------------------------------------------
+-- Stake signing key (private)
+-------------------------------------------------------------------------------
+
+-- |
+--
+-- >>> "5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290" :: GYStakeSigningKey
+-- GYStakeSigningKey "5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290"
+--
+newtype GYStakeSigningKey = GYStakeSigningKey (Api.SigningKey Api.StakeKey)
+    deriving stock Show
+    deriving newtype IsString
+
+instance Eq GYStakeSigningKey where
+    (==) = (==) `on` show
+
+instance Ord GYStakeSigningKey where
+    compare = compare `on` show
+
+instance ToShelleyWitnessSigningKey GYStakeSigningKey where
+  toShelleyWitnessSigningKey (GYStakeSigningKey skey) = Api.WitnessStakeKey skey
+
+-- Handle key for extended signing key
+newtype GYExtendedStakeSigningKey = GYExtendedStakeSigningKey (Api.SigningKey Api.StakeExtendedKey)
+    deriving stock Show
+    deriving newtype IsString
+
+instance Eq GYExtendedStakeSigningKey where
+    (==) = (==) `on` show
+
+instance Ord GYExtendedStakeSigningKey where
+    compare = compare `on` show
+
+instance ToShelleyWitnessSigningKey GYExtendedStakeSigningKey where
+  toShelleyWitnessSigningKey (GYExtendedStakeSigningKey skey) = Api.WitnessStakeExtendedKey skey
+
+-- |
+--
+-- >>> stakeSigningKeyFromApi "5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290"
+-- GYStakeSigningKey "5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290"
+--
+stakeSigningKeyFromApi :: Api.SigningKey Api.StakeKey -> GYStakeSigningKey
+stakeSigningKeyFromApi = coerce
+
+extendedStakeSigningKeyFromApi :: Api.SigningKey Api.StakeExtendedKey -> GYExtendedStakeSigningKey
+extendedStakeSigningKeyFromApi = coerce
+
+-- |
+--
+-- >>> stakeSigningKeyToApi "5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290"
+-- "5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290"
+--
+stakeSigningKeyToApi :: GYStakeSigningKey -> Api.SigningKey Api.StakeKey
+stakeSigningKeyToApi = coerce
+
+extendedStakeSigningKeyToApi :: GYExtendedStakeSigningKey -> Api.SigningKey Api.StakeExtendedKey
+extendedStakeSigningKeyToApi = coerce
+
+-- | Reads a stake signing key from a file.
+--
+readStakeSigningKey :: FilePath -> IO GYStakeSigningKey
+readStakeSigningKey fp = do
+    s <- Api.readFileTextEnvelope (Api.AsSigningKey Api.AsStakeKey) (Api.File fp)
+    case s of
+        Left err -> fail (show err) --- throws IOError
+        Right x  -> return (GYStakeSigningKey x)
+
+-- | Reads extended stake signing key from file
+--
+readExtendedStakeSigningKey :: FilePath -> IO GYExtendedStakeSigningKey
+readExtendedStakeSigningKey fp = do
+    s <- Api.readFileTextEnvelope (Api.AsSigningKey Api.AsStakeExtendedKey) (Api.File fp)
+    case s of
+        Left err -> fail (show err) --- throws IOError
+        Right x  -> return $ GYExtendedStakeSigningKey x
+
+-- | Writes a stake signing key to a file.
+--
+writeStakeSigningKey :: FilePath -> GYStakeSigningKey -> IO ()
+writeStakeSigningKey file key = do
+    e <- Api.writeFileTextEnvelope (Api.File file) (Just "Stake Signing Key") $ stakeSigningKeyToApi key
+    case e of
+        Left (err :: Api.FileError ()) -> throwIO $ userError $ show err
+        Right ()                       -> return ()
+
+-- | Writes a extended stake signing key to a file.
+--
+writeExtendedStakeSigningKey :: FilePath -> GYExtendedStakeSigningKey -> IO ()
+writeExtendedStakeSigningKey file key = do
+    e <- Api.writeFileTextEnvelope (Api.File file) (Just "Extended Stake Signing Key") $ extendedStakeSigningKeyToApi key
+    case e of
+        Left (err :: Api.FileError ()) -> throwIO $ userError $ show err
+        Right ()                       -> return ()
+
+-- |
+--
+-- >>> stakeVerificationKey "5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290"
+-- GYStakeVerificationKey "0717bc56ed4897c3dde0690e3d9ce61e28a55f520fde454f6b5b61305b193605"
+--
+stakeVerificationKey :: GYStakeSigningKey -> GYStakeVerificationKey
+stakeVerificationKey = GYStakeVerificationKey . Api.getVerificationKey . stakeSigningKeyToApi
+
+-- |
+--
+-- >>> LBS8.putStrLn $ Aeson.encode ("5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290" :: GYStakeSigningKey)
+-- "58205ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290"
+--
+instance Aeson.ToJSON GYStakeSigningKey where
+    toJSON = Aeson.String . TE.decodeUtf8 . BS16.encode . Api.serialiseToCBOR . stakeSigningKeyToApi
+
+-- |
+--
+-- >>> Aeson.eitherDecode @GYStakeSigningKey "\"58205ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290\""
+-- Right (GYStakeSigningKey "5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290")
+--
+-- >>> Aeson.eitherDecode @GYStakeSigningKey "\"58205ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fceczzz\""
+-- Left "Error in $: invalid character at offset: 65"
+--
+instance Aeson.FromJSON GYStakeSigningKey where
+    parseJSON (Aeson.String t) = case BS16.decode $ BS8.pack $ T.unpack t of
+        Left err -> fail err
+        Right bs -> case Api.deserialiseFromCBOR (Api.AsSigningKey Api.AsStakeKey) bs of
+            Left err   -> fail $ show err
+            Right skey -> return $ GYStakeSigningKey skey
+    parseJSON _ = fail "stake signing key expected"
+
+
+instance Csv.ToField GYStakeSigningKey where
+  toField = LBS.toStrict . Aeson.encode
+
+instance Csv.FromField GYStakeSigningKey where
+  parseField k =
+      case Aeson.decode $ LBS.fromStrict k of
+        Just v  -> pure v
+        Nothing -> fail $ "Error Parsing stakeSigningKey from CSV: " <> show k
+
+-- |
+--
+-- >>> Printf.printf "%s\n" ("5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290" :: GYStakeSigningKey)
+-- 5ac75cb3435ef38c5bf15d11469b301b13729deb9595133a608fc0881fcec290
+--
+instance Printf.PrintfArg GYStakeSigningKey where
+    formatArg = Printf.formatArg . Api.serialiseToRawBytesHexText . stakeSigningKeyToApi
+
+-- | Generates a new random stake signing key.
+--
+generateStakeSigningKey :: IO GYStakeSigningKey
+generateStakeSigningKey = stakeSigningKeyFromApi <$> Api.generateSigningKey Api.AsStakeKey
+
+data GYSomeSigningKey = forall a. (ToShelleyWitnessSigningKey a, Show a) => GYSomeSigningKey a
 
 readSomeSigningKey :: FilePath -> IO GYSomeSigningKey
 readSomeSigningKey file = do
     e <- Api.readFileTextEnvelopeAnyOf
         [ Api.FromSomeType (Api.AsSigningKey Api.AsPaymentKey)         $ GYSomeSigningKey . paymentSigningKeyFromApi
         , Api.FromSomeType (Api.AsSigningKey Api.AsPaymentExtendedKey) $ GYSomeSigningKey . extendedPaymentSigningKeyFromApi
+        , Api.FromSomeType (Api.AsSigningKey Api.AsStakeKey)           $ GYSomeSigningKey . stakeSigningKeyFromApi
+        , Api.FromSomeType (Api.AsSigningKey Api.AsStakeExtendedKey)   $ GYSomeSigningKey . extendedStakeSigningKeyFromApi
         ] (Api.File file)
     case e of
         Left err   -> throwIO $ userError $ show err

--- a/src/GeniusYield/Types/Key/Class.hs
+++ b/src/GeniusYield/Types/Key/Class.hs
@@ -8,7 +8,7 @@ Stability   : develop
 -}
 module GeniusYield.Types.Key.Class (
   ToShelleyWitnessSigningKey,
-  toShelleyWitnessSigningKey
+  toShelleyWitnessSigningKey,
 ) where
 
 import qualified Cardano.Api as Api

--- a/src/GeniusYield/Types/PaymentKeyHash.hs
+++ b/src/GeniusYield/Types/PaymentKeyHash.hs
@@ -1,0 +1,171 @@
+{-|
+Module      : GeniusYield.Types.PaymentKeyHash
+Copyright   : (c) 2023 GYELD GMBH
+License     : Apache 2.0
+Maintainer  : support@geniusyield.co
+Stability   : develop
+
+-}
+module GeniusYield.Types.PaymentKeyHash (
+    GYPaymentKeyHash,
+    paymentKeyHashFromPlutus,
+    paymentKeyHashToPlutus,
+    paymentKeyHashToApi,
+    paymentKeyHashFromApi,
+) where
+
+import qualified Cardano.Api                  as Api
+import           Control.Lens                 ((?~))
+import qualified Data.Aeson.Types             as Aeson
+import qualified Data.Csv                     as Csv
+import qualified Data.Swagger                 as Swagger
+import qualified Data.Swagger.Internal.Schema as Swagger
+import qualified Data.Text                    as Text
+import qualified Data.Text.Encoding           as Text
+import           GeniusYield.Imports
+import           GeniusYield.Types.Ledger
+import           GeniusYield.Types.PubKeyHash (CanSignTx (..))
+import qualified PlutusLedgerApi.V1.Crypto    as Plutus
+import qualified PlutusTx.Builtins            as Plutus
+import qualified PlutusTx.Builtins.Internal   as Plutus
+import qualified Text.Printf                  as Printf
+import           Unsafe.Coerce                (unsafeCoerce)
+
+-- $setup
+--
+-- >>> :set -XOverloadedStrings -XTypeApplications
+-- >>> import qualified Data.Aeson                 as Aeson
+-- >>> import qualified Data.ByteString.Lazy.Char8 as LBS8
+-- >>> import qualified Data.Csv                   as Csv
+-- >>> import qualified Text.Printf                as Printf
+
+newtype GYPaymentKeyHash = GYPaymentKeyHash (Api.Hash Api.PaymentKey)
+    deriving stock Show
+    deriving newtype (Eq, Ord, IsString)
+
+instance CanSignTx GYPaymentKeyHash where
+  toPubKeyHash = unsafeCoerce  -- We could have exported `GYPubKeyHash` from an internal module but `GYPubKeyHash` needs an overhaul anyways.
+  fromPubKeyHash = unsafeCoerce
+
+-- |
+--
+-- >>> paymentKeyHashFromPlutus "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"
+-- Right (GYPaymentKeyHash "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d")
+--
+-- >>> paymentKeyHashFromPlutus "abcd"
+-- Left (DeserialiseRawBytesError {ptceTag = "paymentKeyHashFromPlutus \"\\171\\205\", error: SerialiseAsRawBytesError {unSerialiseAsRawBytesError = \"Unable to deserialise Hash PaymentKey\"}"})
+--
+paymentKeyHashFromPlutus :: Plutus.PubKeyHash -> Either PlutusToCardanoError GYPaymentKeyHash
+paymentKeyHashFromPlutus (Plutus.PubKeyHash (Plutus.BuiltinByteString h)) =
+    bimap
+        (\e -> DeserialiseRawBytesError $ Text.pack $ "paymentKeyHashFromPlutus " ++ show h ++ ", error: " ++ show e)
+        GYPaymentKeyHash
+    $ Api.deserialiseFromRawBytes (Api.AsHash Api.AsPaymentKey) h
+
+
+
+{-
+    (\case
+        Conv.Tag t Conv.DeserialisationError ->
+            DeserialiseRawBytesError (Txt.pack $ "paymentKeyHashFromPlutus" ++ '.':t)
+        _ -> UnknownPlutusToCardanoError "paymentKeyHashFromPlutus"
+    )
+    GYPaymentKeyHash
+    $ Conv.toCardanoPaymentKeyHash (Plutus.PaymentPubKeyHash h)
+-}
+
+-- |
+--
+-- >>> let Just pkh = Aeson.decode @GYPaymentKeyHash "\"e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d\""
+-- >>> paymentKeyHashToPlutus pkh
+-- e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d
+--
+paymentKeyHashToPlutus :: GYPaymentKeyHash -> Plutus.PubKeyHash
+paymentKeyHashToPlutus = coerce fromCardanoPaymentKeyHash where
+    -- this is not exported from plutus-ledger
+    fromCardanoPaymentKeyHash :: Api.Hash Api.PaymentKey -> Plutus.PubKeyHash
+    fromCardanoPaymentKeyHash paymentKeyHash = Plutus.PubKeyHash $ Plutus.toBuiltin $ Api.serialiseToRawBytes paymentKeyHash
+
+-- |
+--
+-- >>> let Just pkh = Aeson.decode @GYPaymentKeyHash "\"e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d\""
+-- >>> paymentKeyHashToApi pkh
+-- "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"
+--
+paymentKeyHashToApi :: GYPaymentKeyHash -> Api.Hash Api.PaymentKey
+paymentKeyHashToApi = coerce
+
+-- |
+--
+-- >>> paymentKeyHashFromApi "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"
+-- GYPaymentKeyHash "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"
+--
+paymentKeyHashFromApi :: Api.Hash Api.PaymentKey -> GYPaymentKeyHash
+paymentKeyHashFromApi = coerce
+
+-- |
+--
+-- >>> let Just pkh = Aeson.decode @GYPaymentKeyHash "\"e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d\""
+-- >>> LBS8.putStrLn $ Aeson.encode pkh
+-- "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"
+--
+instance Aeson.ToJSON GYPaymentKeyHash where
+    toJSON = Aeson.toJSON . Api.serialiseToRawBytesHexText . paymentKeyHashToApi
+
+-- |
+--
+-- >>> Aeson.eitherDecode @GYPaymentKeyHash "\"e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d\""
+-- Right (GYPaymentKeyHash "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d")
+--
+-- Invalid characters:
+--
+-- >>> Aeson.eitherDecode @GYPaymentKeyHash "\"e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6azzz\""
+-- Left "Error in $: RawBytesHexErrorBase16DecodeFail \"e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6azzz\" \"invalid character at offset: 53\""
+--
+instance Aeson.FromJSON GYPaymentKeyHash where
+    parseJSON = Aeson.withText "GYPaymentKeyHash" $
+        either
+            (fail . show)
+            (return . GYPaymentKeyHash)
+        . Api.deserialiseFromRawBytesHex (Api.AsHash Api.AsPaymentKey)
+        . Text.encodeUtf8
+
+-- |
+--
+-- >>> Printf.printf "%s\n" $ paymentKeyHashFromApi "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"
+-- e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d
+--
+instance Printf.PrintfArg GYPaymentKeyHash where
+    formatArg = Printf.formatArg . Api.serialiseToRawBytesHexText . paymentKeyHashToApi
+
+-- |
+--
+-- >>> Csv.toField @GYPaymentKeyHash "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"
+-- "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"
+--
+instance Csv.ToField GYPaymentKeyHash where
+    toField = Api.serialiseToRawBytesHex . paymentKeyHashToApi
+
+-- |
+--
+-- >>> Csv.runParser $ Csv.parseField @GYPaymentKeyHash "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d"
+-- Right (GYPaymentKeyHash "e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d")
+--
+-- >>> Csv.runParser $ Csv.parseField @GYPaymentKeyHash "not a payment key hash"
+-- Left "RawBytesHexErrorBase16DecodeFail \"not a payment key hash\" \"invalid character at offset: 0\""
+--
+instance Csv.FromField GYPaymentKeyHash where
+    parseField = either (fail . show) (return . paymentKeyHashFromApi) . Api.deserialiseFromRawBytesHex (Api.AsHash Api.AsPaymentKey)
+
+-------------------------------------------------------------------------------
+-- swagger schema
+-------------------------------------------------------------------------------
+
+instance Swagger.ToSchema GYPaymentKeyHash where
+  declareNamedSchema _ = pure $ Swagger.named "GYPaymentKeyHash" $ mempty
+                       & Swagger.type_           ?~ Swagger.SwaggerString
+                       & Swagger.format          ?~ "hex"
+                       & Swagger.description     ?~ "The hash of a payment public key."
+                       & Swagger.example         ?~ toJSON ("e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d" :: Text)
+                       & Swagger.maxLength       ?~ 56
+                       & Swagger.minLength ?~ 56

--- a/src/GeniusYield/Types/PaymentKeyHash.hs
+++ b/src/GeniusYield/Types/PaymentKeyHash.hs
@@ -62,18 +62,6 @@ paymentKeyHashFromPlutus (Plutus.PubKeyHash (Plutus.BuiltinByteString h)) =
         GYPaymentKeyHash
     $ Api.deserialiseFromRawBytes (Api.AsHash Api.AsPaymentKey) h
 
-
-
-{-
-    (\case
-        Conv.Tag t Conv.DeserialisationError ->
-            DeserialiseRawBytesError (Txt.pack $ "paymentKeyHashFromPlutus" ++ '.':t)
-        _ -> UnknownPlutusToCardanoError "paymentKeyHashFromPlutus"
-    )
-    GYPaymentKeyHash
-    $ Conv.toCardanoPaymentKeyHash (Plutus.PaymentPubKeyHash h)
--}
-
 -- |
 --
 -- >>> let Just pkh = Aeson.decode @GYPaymentKeyHash "\"e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d\""

--- a/src/GeniusYield/Types/PubKeyHash.hs
+++ b/src/GeniusYield/Types/PubKeyHash.hs
@@ -66,18 +66,6 @@ pubKeyHashFromPlutus (Plutus.PubKeyHash (Plutus.BuiltinByteString h)) =
         GYPubKeyHash
     $ Api.deserialiseFromRawBytes (Api.AsHash Api.AsPaymentKey) h
 
-
-
-{-
-    (\case
-        Conv.Tag t Conv.DeserialisationError ->
-            DeserialiseRawBytesError (Txt.pack $ "pubKeyHashFromPlutus" ++ '.':t)
-        _ -> UnknownPlutusToCardanoError "pubKeyHashFromPlutus"
-    )
-    GYPubKeyHash
-    $ Conv.toCardanoPaymentKeyHash (Plutus.PaymentPubKeyHash h)
--}
-
 -- |
 --
 -- >>> let Just pkh = Aeson.decode @GYPubKeyHash "\"e1cbb80db89e292269aeb93ec15eb963dda5176b66949fe1c2a6a38d\""

--- a/src/GeniusYield/Types/PubKeyHash.hs
+++ b/src/GeniusYield/Types/PubKeyHash.hs
@@ -7,7 +7,8 @@ Stability   : develop
 
 -}
 module GeniusYield.Types.PubKeyHash (
-    GYPubKeyHash,
+    GYPubKeyHash (..),
+    CanSignTx (..),
     pubKeyHashFromPlutus,
     pubKeyHashToPlutus,
     pubKeyHashToApi,
@@ -41,6 +42,14 @@ import qualified Text.Printf                  as Printf
 newtype GYPubKeyHash = GYPubKeyHash (Api.Hash Api.PaymentKey)
     deriving stock Show
     deriving newtype (Eq, Ord, IsString)
+
+class CanSignTx a where
+  toPubKeyHash :: a -> GYPubKeyHash
+  fromPubKeyHash :: GYPubKeyHash -> a
+
+instance CanSignTx GYPubKeyHash where
+  toPubKeyHash = id
+  fromPubKeyHash = id
 
 -- |
 --

--- a/src/GeniusYield/Types/StakeKeyHash.hs
+++ b/src/GeniusYield/Types/StakeKeyHash.hs
@@ -21,7 +21,9 @@ import qualified Data.Csv                     as Csv
 import qualified Data.Swagger                 as Swagger
 import qualified Data.Swagger.Internal.Schema as Swagger
 import qualified Data.Text.Encoding           as Text
+import           GeniusYield.Types.PubKeyHash (CanSignTx (..))
 import qualified Text.Printf                  as Printf
+import           Unsafe.Coerce                (unsafeCoerce)
 
 -- $setup
 --
@@ -34,6 +36,10 @@ import qualified Text.Printf                  as Printf
 newtype GYStakeKeyHash = GYStakeKeyHash (Api.Hash Api.StakeKey)
     deriving stock Show
     deriving newtype (Eq, Ord, IsString)
+
+instance CanSignTx GYStakeKeyHash where
+  toPubKeyHash = unsafeCoerce
+  fromPubKeyHash = unsafeCoerce
 
 -- |
 --

--- a/tests/GeniusYield/Test/Providers/Mashup.hs
+++ b/tests/GeniusYield/Test/Providers/Mashup.hs
@@ -98,7 +98,7 @@ providersMashupTests configs =
     , testCase "Submitting a valid transaction" $ do
         skey <- readPaymentSigningKey "preprod-submit-test-wallet.skey"
         let nid = GYTestnetPreprod
-            senderAddress = addressFromPubKeyHash GYTestnetPreprod $ pubKeyHash $ paymentVerificationKey skey
+            senderAddress = addressFromPaymentKeyHash GYTestnetPreprod $ paymentKeyHash $ paymentVerificationKey skey
         forM_ configs $ \config -> withCfgProviders config mempty $ \provider@GYProviders {..} -> do
           delayBySecond
           senderUTxOs <- runGYTxQueryMonadNode nid provider $ utxosAtAddress senderAddress Nothing


### PR DESCRIPTION
This PR adds support in Atlas for stake keys. In particular, support is provided to load private stake signing keys from file and ability to require stake key hash in transaction skeleton.

Attempt has been made to keep breaking changes at minimal, in particular two changes are breaking:
* `newTempUserCtx` now accepts a configuration instead of a boolean.
* Fields of `User` type have been updated.
* `GYPaymentCredentialByKey` now requires `GYPaymentKeyHash` instead of `GYPubKeyHash`.

In future, we should simplify our API interface to access for keys, like how `cardano-api` does it [here](https://cardano-api.cardano.intersectmbo.org/cardano-api/Cardano-Api-Keys-Class.html#t:Key). Issue for it is created [here](https://github.com/geniusyield/atlas/issues/277).

Closes #276.
Builds on top of #274.