### PR TITLE
Fix FeeTracker not tracking min ada deposit gains

### DIFF
--- a/src/GeniusYield/Test/Clb.hs
+++ b/src/GeniusYield/Test/Clb.hs
@@ -98,7 +98,8 @@ asRandClb :: User
 asRandClb w m = do
     e <- runExceptT $ unGYTxMonadClb m `runReaderT` GYTxRunEnv w
     case e of
-        Left err -> lift (logError (show err)) >> return Nothing
+        Left (GYApplicationException (toApiError -> GYApiError {gaeMsg})) -> lift (logError $ T.unpack gaeMsg) >> return Nothing
+        Left err -> lift (logError $ show err) >> return Nothing
         Right a -> return $ Just a
 
 asClb :: StdGen


### PR DESCRIPTION
Little edge case that I missed since it's actually not tested for much at all!

Currently, the FeeTracker doesn't actually account for the fact that when "own user" loses ada to min ada deposits, _some other user_ actually **gains** that deposit as "extra unexpected ada" (unexpected by the smart contract). So if we perform multi user tests and try to make sure all users balances changed as expected (not just own user) - the test will fail because some user actually got _more_ ada than expected.

This patch fixes it.

Also adds `withoutFeeTracking` in light of the removal of submitted tx tracking. We now assume that all `buildTxBody` (or sister functions) are called with the _intent_ of submitting the transaction. If this is not the case, the user can explicitly wrap said call with a `withoutFeeTracking`.