### PR TITLE
Make feetracker track unexpected gains from inputs

### DIFF
--- a/atlas-cardano.cabal
+++ b/atlas-cardano.cabal
@@ -294,8 +294,11 @@ test-suite atlas-tests
   other-modules:
     GeniusYield.Test.CoinSelection
     GeniusYield.Test.Config
+    GeniusYield.Test.FeeTracking
     GeniusYield.Test.GYTxBody
     GeniusYield.Test.GYTxSkeleton
+    GeniusYield.Test.OnChain.AlwaysSucceeds
+    GeniusYield.Test.OnChain.AlwaysSucceeds.Compiled
     GeniusYield.Test.OnChain.GuessRefInputDatum
     GeniusYield.Test.OnChain.GuessRefInputDatum.Compiled
     GeniusYield.Test.Providers

--- a/src/GeniusYield/Transaction/Common.hs
+++ b/src/GeniusYield/Transaction/Common.hs
@@ -13,6 +13,7 @@ module GeniusYield.Transaction.Common (
   GYBuildTxError (..),
   GYBalancingError (..),
   minimumUTxO,
+  minimumApiUTxO,
   adjustTxOut,
 ) where
 
@@ -126,11 +127,14 @@ data GYBuildTxError
 -- Transaction Utilities
 -------------------------------------------------------------------------------
 
-minimumUTxO :: ApiProtocolParameters -> GYTxOut v -> Natural
-minimumUTxO pp txOut =
+minimumApiUTxO :: ApiProtocolParameters -> Api.TxOut Api.CtxTx ApiEra -> Natural
+minimumApiUTxO pp txOut =
   fromInteger $
     coerce $
-      Api.calculateMinimumUTxO Api.ShelleyBasedEraConway (txOutToApi txOut) pp
+      Api.calculateMinimumUTxO Api.ShelleyBasedEraConway txOut pp
+
+minimumUTxO :: ApiProtocolParameters -> GYTxOut v -> Natural
+minimumUTxO pp = minimumApiUTxO pp . txOutToApi
 
 adjustTxOut :: (GYTxOut v -> Natural) -> GYTxOut v -> GYTxOut v
 adjustTxOut minimumUTxOF = helper

--- a/tests/GeniusYield/Test/FeeTracking.hs
+++ b/tests/GeniusYield/Test/FeeTracking.hs
@@ -1,0 +1,149 @@
+{- |
+Module      : GeniusYield.Test.FeeTracking
+Copyright   : (c) 2023 GYELD GMBH
+License     : Apache 2.0
+Maintainer  : support@geniusyield.com
+Stability   : develop
+-}
+module GeniusYield.Test.FeeTracking (feeTrackingTests) where
+
+import Test.Tasty
+
+import GeniusYield.Test.Clb
+import GeniusYield.Test.Utils
+import GeniusYield.TxBuilder
+import GeniusYield.Types
+
+import GeniusYield.Test.OnChain.AlwaysSucceeds.Compiled
+
+data LovelaceConfig = WithLovelace | WithoutLovelace
+
+mkAmt :: LovelaceConfig -> GYValue -> GYValue
+mkAmt WithLovelace = (valueFromLovelace 10_000_000 <>)
+mkAmt WithoutLovelace = (mempty <>)
+
+type TestFunction = forall m. GYTxGameMonad m => Wallets -> GYValue -> m ()
+
+feeTrackingTests :: TestTree
+feeTrackingTests =
+  testGroup
+    "feetracker"
+    [ mkTestFor "send to another" $ prepTest WithLovelace sendToOther
+    , mkTestFor "send (no lovelace) to another" $ prepTest WithoutLovelace sendToOther
+    , mkTestFor "send to address as w1, consume from address as w2" $ prepTest WithLovelace sendAndConsume
+    , mkTestFor "send (no lovelace) to address as w1, consume from address as w2" $
+        prepTest WithoutLovelace sendAndConsume
+    , mkTestFor "send to address as w1, consume from address as w2 to create continuing output" $
+        prepTest WithLovelace sendAndContinue
+    , mkTestFor "send (without lovelace) to address as w1, consume from address as w2 to create continuing output" $
+        prepTest WithoutLovelace sendAndContinue
+    , mkTestFor "send to address as w1, consume from address as w1" $ prepTest WithLovelace selfConsume
+    , mkTestFor "send (without lovelace) to address as w1, consume from address as w1" $ prepTest WithoutLovelace selfConsume
+    , mkTestFor "send to address as w1, consume from address as w1 to create continuing output" $
+        prepTest WithLovelace selfContinue
+    , mkTestFor "send (without lovelace) to address as w1, consume from address as w1 to create continuing output" $
+        prepTest WithoutLovelace selfContinue
+    , mkTestFor "send to address as w1, partially consume from address as w1 to create partial continuing output" $
+        selfPartialConsume WithLovelace
+    , mkTestFor "send (without lovelace) to address as w1, partially consume from address as w1 to create partial continuing output" $
+        selfPartialConsume WithoutLovelace
+    ]
+
+sendToOther :: TestFunction
+sendToOther Wallets {w1, w2} amt = withWalletBalancesCheckSimple [w1 := valueNegate amt, w2 := amt] . asUser w1 $ do
+  txBody <- buildTxBody . mustHaveOutput $ mkGYTxOut (userChangeAddress w2) amt unitDatum
+  signAndSubmitConfirmed_ txBody
+
+sendAndConsume :: TestFunction
+sendAndConsume Wallets {w1, w2} amt = withWalletBalancesCheckSimple [w1 := valueNegate amt, w2 := amt] $ do
+  target <- scriptAddress gyAlwaysSucceedsValidator
+  txId <- asUser w1 $ do
+    txBody <- buildTxBody . mustHaveOutput $ mkGYTxOut target amt unitDatum
+    signAndSubmitConfirmed txBody
+  asUser w2 $ do
+    txBody <-
+      buildTxBody @PlutusV1 . mustHaveInput $
+        GYTxIn
+          { gyTxInWitness = GYTxInWitnessScript (GYInScript gyAlwaysSucceedsValidator) unitDatum unitRedeemer
+          , gyTxInTxOutRef = txOutRefFromTuple (txId, 0)
+          }
+    signAndSubmitConfirmed_ txBody
+
+sendAndContinue :: TestFunction
+sendAndContinue Wallets {w1, w2} amt = withWalletBalancesCheckSimple [w1 := valueNegate amt, w2 := mempty] $ do
+  target <- scriptAddress gyAlwaysSucceedsValidator
+  txId <- asUser w1 $ do
+    txBody <- buildTxBody . mustHaveOutput $ mkGYTxOut target amt unitDatum
+    signAndSubmitConfirmed txBody
+  asUser w2 $ do
+    txBody <-
+      buildTxBody @PlutusV1 $
+        mconcat
+          [ mustHaveInput $
+              GYTxIn
+                { gyTxInWitness = GYTxInWitnessScript (GYInScript gyAlwaysSucceedsValidator) unitDatum unitRedeemer
+                , gyTxInTxOutRef = txOutRefFromTuple (txId, 0)
+                }
+          , mustHaveOutput $ mkGYTxOut target amt unitDatum
+          ]
+    signAndSubmitConfirmed_ txBody
+
+selfConsume :: TestFunction
+selfConsume Wallets {w1} amt = withWalletBalancesCheckSimple [w1 := mempty] $ do
+  target <- scriptAddress gyAlwaysSucceedsValidator
+  asUser w1 $ do
+    sendBody <- buildTxBody . mustHaveOutput $ mkGYTxOut target amt unitDatum
+    txId <- signAndSubmitConfirmed sendBody
+    consumeBody <-
+      buildTxBody @PlutusV1 . mustHaveInput $
+        GYTxIn
+          { gyTxInWitness = GYTxInWitnessScript (GYInScript gyAlwaysSucceedsValidator) unitDatum unitRedeemer
+          , gyTxInTxOutRef = txOutRefFromTuple (txId, 0)
+          }
+    signAndSubmitConfirmed_ consumeBody
+
+selfContinue :: TestFunction
+selfContinue Wallets {w1} amt = withWalletBalancesCheckSimple [w1 := valueNegate amt] $ do
+  target <- scriptAddress gyAlwaysSucceedsValidator
+  asUser w1 $ do
+    sendBody <- buildTxBody . mustHaveOutput $ mkGYTxOut target amt unitDatum
+    txId <- signAndSubmitConfirmed sendBody
+    continueBody <-
+      buildTxBody @PlutusV1 $
+        mconcat
+          [ mustHaveInput $
+              GYTxIn
+                { gyTxInWitness = GYTxInWitnessScript (GYInScript gyAlwaysSucceedsValidator) unitDatum unitRedeemer
+                , gyTxInTxOutRef = txOutRefFromTuple (txId, 0)
+                }
+          , mustHaveOutput $ mkGYTxOut target amt unitDatum
+          ]
+    signAndSubmitConfirmed_ continueBody
+
+selfPartialConsume :: GYTxGameMonad m => LovelaceConfig -> TestInfo -> m ()
+selfPartialConsume lovelaceConf TestInfo {testWallets = Wallets {w1}, testGoldAsset} = do
+  let amt = mkAmt lovelaceConf $ valueSingleton testGoldAsset 10
+      partialAmt = mkAmt lovelaceConf $ valueSingleton testGoldAsset 5
+  withWalletBalancesCheckSimple [w1 := valueNegate partialAmt] $ do
+    target <- scriptAddress gyAlwaysSucceedsValidator
+    asUser w1 $ do
+      sendBody <- buildTxBody . mustHaveOutput $ mkGYTxOut target amt unitDatum
+      txId <- signAndSubmitConfirmed sendBody
+      continueBody <-
+        buildTxBody @PlutusV1 $
+          mconcat
+            [ mustHaveInput $
+                GYTxIn
+                  { gyTxInWitness = GYTxInWitnessScript (GYInScript gyAlwaysSucceedsValidator) unitDatum unitRedeemer
+                  , gyTxInTxOutRef = txOutRefFromTuple (txId, 0)
+                  }
+            , mustHaveOutput $ mkGYTxOut target partialAmt unitDatum
+            ]
+      signAndSubmitConfirmed_ continueBody
+
+prepTest :: GYTxGameMonad m => LovelaceConfig -> TestFunction -> TestInfo -> m ()
+prepTest lovelaceConf f TestInfo {testWallets, testGoldAsset} =
+  f testWallets . mkAmt lovelaceConf $ valueSingleton testGoldAsset 10
+
+gyAlwaysSucceedsValidator :: GYValidator 'PlutusV2
+gyAlwaysSucceedsValidator = validatorFromPlutus alwaysSucceedsValidator

--- a/tests/GeniusYield/Test/OnChain/AlwaysSucceeds.hs
+++ b/tests/GeniusYield/Test/OnChain/AlwaysSucceeds.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+{- |
+Module      : GeniusYield.Test.OnChain.AlwaysSucceeds
+Copyright   : (c) 2023 GYELD GMBH
+License     : Apache 2.0
+Maintainer  : support@geniusyield.com
+Stability   : develop
+-}
+module GeniusYield.Test.OnChain.AlwaysSucceeds (
+  mkAlwaysSucceedsValidator,
+) where
+
+import PlutusLedgerApi.V2
+
+{-# INLINEABLE mkAlwaysSucceedsValidator #-}
+mkAlwaysSucceedsValidator :: BuiltinData -> BuiltinData -> BuiltinData -> ()
+mkAlwaysSucceedsValidator _ _ _ = ()

--- a/tests/GeniusYield/Test/OnChain/AlwaysSucceeds/Compiled.hs
+++ b/tests/GeniusYield/Test/OnChain/AlwaysSucceeds/Compiled.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{- |
+Module      : GeniusYield.Test.OnChain.AlwaysSucceeds.Compiled
+Copyright   : (c) 2023 GYELD GMBH
+License     : Apache 2.0
+Maintainer  : support@geniusyield.com
+Stability   : develop
+-}
+module GeniusYield.Test.OnChain.AlwaysSucceeds.Compiled (alwaysSucceedsValidator) where
+
+import PlutusTx qualified
+
+import GeniusYield.Test.OnChain.AlwaysSucceeds
+
+alwaysSucceedsValidator :: PlutusTx.CompiledCode (PlutusTx.BuiltinData -> PlutusTx.BuiltinData -> PlutusTx.BuiltinData -> ())
+alwaysSucceedsValidator = $$(PlutusTx.compile [||mkAlwaysSucceedsValidator||])

--- a/tests/atlas-tests.hs
+++ b/tests/atlas-tests.hs
@@ -22,6 +22,7 @@ import GeniusYield.GYConfig (
 import GeniusYield.Imports
 import GeniusYield.Test.CoinSelection (coinSelectionTests)
 import GeniusYield.Test.Config (configTests)
+import GeniusYield.Test.FeeTracking (feeTrackingTests)
 import GeniusYield.Test.GYTxBody (gyTxBodyTests)
 import GeniusYield.Test.GYTxSkeleton (gyTxSkeletonTests)
 import GeniusYield.Test.Providers (providersTests)
@@ -80,6 +81,7 @@ main = do
       , configTests
       , gyTxSkeletonTests
       , refInputTests
+      , feeTrackingTests
       , stakeTests (head configs)
       , providersTests configs providerToken netId
       ]


### PR DESCRIPTION
This lets the feetracker track gains from min ada deposits consumed from inputs.

Previously, tests like these would fail:

```hs
let amt = valueSingleton valueSingleton testGoldAsset 10
withWalletBalancesCheckSimple [w1 := valueNegate amt, w2 := amt] $ do
    target <- scriptAddress gyAlwaysSucceedsValidator
    txId <- asUser w1 $ do
        txBody <- buildTxBody . mustHaveOutput $ mkGYTxOut target amt unitDatum
        signAndSubmitConfirmed txBody
    asUser w2 $ do
        txBody <- buildTxBody @PlutusV1 . mustHaveInput $ GYTxIn
            { gyTxInWitness  = GYTxInWitnessScript (GYInScript gyAlwaysSucceedsValidator) unitDatum unitRedeemer
            , gyTxInTxOutRef = txOutRefFromTuple (txId, 0)
            }
        signAndSubmitConfirmed_ txBody
```

Here, `w1` loses some lovelace to paying a deposit to the UTxO created in the first transaction. This is, of course, tracked by fee tracker - so it's all good. However, in the next transaction, `w2` actually _gains_ this deposit. But this is not tracked at all! So there is an _unexpected gain_.

This PR also adds a bunch of tests for feetracker.