### PR TITLE
feat(#399): add `ToJSON GYTxOutRefCbor` instance

### DIFF
--- a/atlas-cardano.cabal
+++ b/atlas-cardano.cabal
@@ -322,6 +322,7 @@ test-suite atlas-tests
     GeniusYield.Test.FeeTracking
     GeniusYield.Test.GYTxBody
     GeniusYield.Test.GYTxSkeleton
+    GeniusYield.Test.GYTxOutRefCbor
     GeniusYield.Test.OnChain.AlwaysSucceeds
     GeniusYield.Test.OnChain.AlwaysSucceeds.Compiled
     GeniusYield.Test.OnChain.GuessRefInputDatum

--- a/src/GeniusYield/Types/TxOutRef.hs
+++ b/src/GeniusYield/Types/TxOutRef.hs
@@ -256,22 +256,34 @@ instance Aeson.FromJSON GYTxOutRefCbor where
       Left err -> fail $ T.unpack err
       Right ref -> return ref
 
+{- | Warning: this JSON instance does not satisfy
+@JSON --> 'GYTxOutRefCbor' --> JSON === id@ since some information in the hex
+encoded CBOR string is lost when going from @'GYTxOutRefCbor'@ to @JSON@.
+
+In practise, this shouldn't be an issue -- see
+<https://github.com/geniusyield/atlas/issues/399#issuecomment-2618617724>
+for details.
+-}
 instance Aeson.ToJSON GYTxOutRefCbor where
-    toJSON (GYTxOutRefCbor gyTxOutRef) =
-        let Api.TxIn txId (Api.TxIx txIx) = GeniusYield.Types.TxOutRef.txOutRefToApi gyTxOutRef
-            someInt = 0 -- NOTE(jaredponn) January 27, 2025: I don't think the
-                        -- value of this int matters, it just needs to be some int.
-        in Aeson.String
-            $ TE.decodeASCII
-            $ Base16.encode
-            $ CBOR.toStrictByteString
-            $ CBOR.encodeTerm
-            $ CBOR.TList
-                [ CBOR.TList
-                    [ CBOR.TBytes $ Api.serialiseToRawBytes txId
-                    , CBOR.TInt $ fromIntegral txIx]
-                , CBOR.TInt someInt
-                ]
+  toJSON (GYTxOutRefCbor gyTxOutRef) =
+    let Api.TxIn txId (Api.TxIx txIx) = GeniusYield.Types.TxOutRef.txOutRefToApi gyTxOutRef
+        -- NOTE(jaredponn) January 27, 2025: the
+        -- value of this int doesn't matter when it is decoded
+        -- with the 'Aeson.FromJSON' instance, so we may pick
+        -- any value -- in particular, we choose 0.
+        someInt = 0
+     in Aeson.String $
+          TE.decodeASCII $
+            Base16.encode $
+              CBOR.toStrictByteString $
+                CBOR.encodeTerm $
+                  CBOR.TList
+                    [ CBOR.TList
+                        [ CBOR.TBytes $ Api.serialiseToRawBytes txId
+                        , CBOR.TInt $ fromIntegral txIx
+                        ]
+                    , CBOR.TInt someInt
+                    ]
 
 -------------------------------------------------------------------------------
 -- swagger schema

--- a/tests/GeniusYield/Test/GYTxOutRefCbor.hs
+++ b/tests/GeniusYield/Test/GYTxOutRefCbor.hs
@@ -1,0 +1,76 @@
+module GeniusYield.Test.GYTxOutRefCbor (
+  gyTxOutRefCborTests,
+) where
+
+import Control.Monad (replicateM)
+import Data.Maybe (fromJust)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Gen, arbitrary, counterexample, elements, forAllShrink, property, shrink, testProperty, (===))
+
+import Data.Aeson (eitherDecode', encode)
+
+import GeniusYield.Types (
+  GYTxOutRef,
+  GYTxOutRefCbor (GYTxOutRefCbor, getTxOutRefHex),
+  txIdFromHex,
+  txOutRefFromTuple,
+  txOutRefToTuple,
+ )
+
+-- | Test group for the 'GYTxOutRefCbor' type
+gyTxOutRefCborTests :: TestTree
+gyTxOutRefCborTests = testGroup "GYTxOutRefCbor" basicTests
+
+basicTests :: [TestTree]
+basicTests =
+  [ testProperty "Roundtrip GYTxOutRefCbor --> JSON --> GYTxOutRefCbor === id" $
+      forAllShrink genGyTxOutRefCbor shrinkGyTxOutRefCbor $ \gyTxOutRefCbor ->
+        let encodedGyTxOutRefCbor = encode gyTxOutRefCbor
+         in counterexample ("JSON encoded GYTxOutRefCbor " ++ show encodedGyTxOutRefCbor) $
+              case eitherDecode' (encode gyTxOutRefCbor) of
+                Right decodedGyTxOutRefCbor ->
+                  counterexample
+                    ("JSON decoded of the encoded GYTxOutRefCbor " ++ show decodedGyTxOutRefCbor)
+                    $
+                    -- NOTE(jaredponn) January 31, 2025: it's a bit
+                    -- weird that 'GYTxOutRefCbor' doesn't have an
+                    -- 'Eq' instance, so we unwrap it and use the
+                    -- underlying 'GYTxOutRef' 'Eq' instance.
+                    getTxOutRefHex gyTxOutRefCbor === getTxOutRefHex decodedGyTxOutRefCbor
+                Left _err -> property False
+  ]
+
+-- | Generator for 'GYTxOutRefCbor'
+genGyTxOutRefCbor :: Gen GYTxOutRefCbor
+genGyTxOutRefCbor = GYTxOutRefCbor <$> genGyTxOutRef
+
+-- | Generator for 'GYTxOutRef'
+genGyTxOutRef :: Gen GYTxOutRef
+genGyTxOutRef = do
+  txId <- fmap
+    ( fromJust
+        -- NOTE(jaredponn) January 31, 2025: this 'fromJust' is safe -- we
+        -- know that TxIds are 32 bytes long, and we generate the strings
+        -- s.t. they are always 32 bytes long
+        . txIdFromHex
+        . concat
+    )
+    $ replicateM 32
+    $ do
+      firstHexDigit <- elements $ ['0' .. '9'] ++ ['a' .. 'f']
+      secondHexDigit <- elements $ ['0' .. '9'] ++ ['a' .. 'f']
+      return [firstHexDigit, secondHexDigit]
+  txIx <- arbitrary
+
+  return $ txOutRefFromTuple (txId, txIx)
+
+-- | Shrinks 'GYTxOutRefCbor' using the underlying 'shrinkGyTxOutRef'
+shrinkGyTxOutRefCbor :: GYTxOutRefCbor -> [GYTxOutRefCbor]
+shrinkGyTxOutRefCbor (GYTxOutRefCbor gyTxOutRef) =
+  map GYTxOutRefCbor $ shrinkGyTxOutRef gyTxOutRef
+
+-- | Shrinks 'GYTxOutRef'. This only shrinks the transaction index.
+shrinkGyTxOutRef :: GYTxOutRef -> [GYTxOutRef]
+shrinkGyTxOutRef gyTxOutRef =
+  let (txId, txIx) = txOutRefToTuple gyTxOutRef
+   in map (\shrunkTxIx -> txOutRefFromTuple (txId, shrunkTxIx)) $ shrink txIx

--- a/tests/atlas-tests.hs
+++ b/tests/atlas-tests.hs
@@ -24,6 +24,7 @@ import GeniusYield.Test.CoinSelection (coinSelectionTests)
 import GeniusYield.Test.Config (configTests)
 import GeniusYield.Test.FeeTracking (feeTrackingTests)
 import GeniusYield.Test.GYTxBody (gyTxBodyTests)
+import GeniusYield.Test.GYTxOutRefCbor (gyTxOutRefCborTests)
 import GeniusYield.Test.GYTxSkeleton (gyTxSkeletonTests)
 import GeniusYield.Test.Providers (providersTests)
 import GeniusYield.Test.RefInput (refInputTests)
@@ -79,6 +80,7 @@ main = do
       , gyTxBodyTests
       , configTests
       , gyTxSkeletonTests
+      , gyTxOutRefCborTests
       , refInputTests
       , feeTrackingTests
       , stakeTests (head configs)


### PR DESCRIPTION
## Summary

This PR:
- [x] adds the `ToJSON GYTxOutRefCbor` instance for issue https://github.com/geniusyield/atlas/issues/399 
- [x] documents some of the issues with this instance (it's not an isomorphism, but in practise this hopefully isn't an issue)
- [x] property based testing of roundtrip tests of the form `GYTxOutRefCbor --> JSON --> GYTxOutRefCbor === id`
## Type of Change

Please mark the relevant option(s) for your pull request:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [x] Documentation update (adding or updating documentation related to the project)

## Checklist

Please ensure that your pull request meets the following criteria:

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's coding style and best practices
- [x] My code is appropriately commented and includes relevant documentation
- [x] I have added tests to cover my changes
- [ ] All new and existing tests pass
- [x] I have updated the documentation, if necessary

## Testing

Please describe the tests you have added or modified, and provide any additional context or instructions needed to run the tests.

- Property based tests which verify that `GYTxOutRefCbor --> JSON --> GYTxOutRefCbor` is the same as `id` is over here https://github.com/geniusyield/atlas/blob/85318864b9e9ec3ceaaea704eaee469a17da7f30/tests/GeniusYield/Test/GYTxOutRefCbor.hs

It was included in the usual test suite `atlas-tests`, so no special instructions are needed to run it.

## Additional Information

Running my tests locally on my computer succeeds with:

```bash
# the test runner was modified to only run my tests.
$ cabal run test:atlas-tests
atlas
  GYTxOutRefCbor
    Roundtrip GYTxOutRefCbor --> JSON --> GYTxOutRefCbor === id: OK
      +++ OK, passed 100 tests.

All 1 tests passed (0.01s)
```

Would be happy to provide any other information as needed :) 