### PR TITLE
[CI] Updated GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -207,7 +207,7 @@ jobs:
     - name: Generate documentation (cabal haddock)
       run: cabal haddock --html --hyperlink-source --haddock-options="--use-unicode" --haddock-quickjump
     - name: Upload haddock documentation
-      uses: actions/upload-pages-artifact@v3.0.1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: ./dist-newstyle/build/x86_64-linux/ghc-9.6.5/${{env.ATLAS_VERSION}}/doc/html/atlas-cardano/
     - name: Upload artifacts


### PR DESCRIPTION

## Summary

Updated GitHub Actions.

Please see the deprecation notice:
- https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

