### PR TITLE
[CI ] Do not generate haddock for dependencies

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -205,7 +205,7 @@ jobs:
         echo "ATLAS_VERSION=${ATLAS_VERSION}" >> $GITHUB_ENV
         echo "ATLAS_VERSION=${ATLAS_VERSION}" >> $GITHUB_OUTPUT
     - name: Generate documentation (cabal haddock)
-      run: cabal haddock --html --hyperlink-source --haddock-options="--use-unicode" --haddock-quickjump
+      run: cabal v2-haddock atlas-cardano --html --hyperlink-source --haddock-options="--use-unicode" --haddock-quickjump
     - name: Upload haddock documentation
       uses: actions/upload-pages-artifact@v3
       with:


### PR DESCRIPTION
## Summary

Changed the CI build to generate haddock only for Atlas.

