### PR TITLE
Add new utilities for some Governance types and ScriptHashes

### DIFF
--- a/src/GeniusYield/Types/Governance.hs
+++ b/src/GeniusYield/Types/Governance.hs
@@ -9,12 +9,16 @@ module GeniusYield.Types.Governance (
   GYVote (..),
   voteFromLedger,
   voteToLedger,
+  voteFromPlutus,
+  voteToPlutus,
   GYVoter (..),
   voterFromLedger,
   voterToLedger,
   GYGovActionId (..),
   govActionIdFromLedger,
   govActionIdToLedger,
+  govActionIdFromPlutus,
+  govActionIdToPlutus,
   GYVotingProcedure (..),
   votingProcedureFromLedger,
   votingProcedureToLedger,
@@ -44,9 +48,13 @@ import Cardano.Api.Ledger (maybeToStrictMaybe, strictMaybeToMaybe)
 import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley qualified as Api
 import Cardano.Ledger.Conway qualified as Conway
+import Data.Either.Combinators (mapLeft)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Data.Word (Word16)
+import Deriving.Aeson qualified as Aeson
+import GHC.Generics (Generic)
 import GeniusYield.Imports (Map, Natural, Set, (&))
 import GeniusYield.Types.Address (GYStakeAddress, stakeAddressFromLedger, stakeAddressToLedger)
 import GeniusYield.Types.Anchor
@@ -55,13 +63,27 @@ import GeniusYield.Types.Credential (GYCredential, credentialFromLedger, credent
 import GeniusYield.Types.Epoch (GYEpochNo, epochNoFromLedger, epochNoToLedger)
 import GeniusYield.Types.KeyHash
 import GeniusYield.Types.KeyRole (GYKeyRole (..))
+import GeniusYield.Types.Ledger (PlutusToCardanoError (UnknownPlutusToCardanoError))
 import GeniusYield.Types.Reexpose (ProtVer, UnitInterval)
 import GeniusYield.Types.Script (GYScriptHash, scriptHashFromLedger, scriptHashToLedger)
 import GeniusYield.Types.Tx (GYTxId, txIdFromApi, txIdToApi)
+import PlutusLedgerApi.V3 qualified as PlutusV3
+import PlutusTx.Builtins.Internal (BuiltinByteString (BuiltinByteString))
 
 -- | Vote on a governance proposal.
 data GYVote = Yes | No | Abstain
-  deriving (Eq, Show, Ord, Enum, Bounded)
+  deriving (Eq, Show, Ord, Enum, Bounded, Generic)
+  deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
+
+voteToPlutus :: GYVote -> PlutusV3.Vote
+voteToPlutus Yes = PlutusV3.VoteYes
+voteToPlutus No = PlutusV3.VoteNo
+voteToPlutus Abstain = PlutusV3.Abstain
+
+voteFromPlutus :: PlutusV3.Vote -> GYVote
+voteFromPlutus PlutusV3.VoteYes = Yes
+voteFromPlutus PlutusV3.VoteNo = No
+voteFromPlutus PlutusV3.Abstain = Abstain
 
 voteToLedger :: GYVote -> Ledger.Vote
 voteToLedger Yes = Ledger.VoteYes
@@ -92,13 +114,35 @@ voterFromLedger (Ledger.StakePoolVoter k) = StakePoolVoter (keyHashFromLedger k)
 
 data GYGovActionId = GYGovActionId
   {gaidTxId :: !GYTxId, gaidIx :: !Word16}
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Show, Ord, Generic)
+  deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 govActionIdToLedger :: GYGovActionId -> Ledger.GovActionId
 govActionIdToLedger (GYGovActionId txId ix) = Ledger.GovActionId (txIdToApi txId & Api.toShelleyTxId) (Ledger.GovActionIx ix)
 
 govActionIdFromLedger :: Ledger.GovActionId -> GYGovActionId
 govActionIdFromLedger (Ledger.GovActionId txId (Ledger.GovActionIx ix)) = GYGovActionId (txIdFromApi (Api.fromShelleyTxId txId)) ix
+
+govActionIdFromPlutus :: PlutusV3.GovernanceActionId -> Either PlutusToCardanoError GYGovActionId
+govActionIdFromPlutus (PlutusV3.GovernanceActionId tid@(PlutusV3.TxId (BuiltinByteString bs)) ix) = GYGovActionId <$> etid <*> eix
+ where
+  etid :: Either PlutusToCardanoError GYTxId
+  etid =
+    mapLeft (\e -> UnknownPlutusToCardanoError $ Text.pack $ "txOutRefFromPlutus: invalid txOutRefId " <> show tid <> ", error: " <> show e) $
+      txIdFromApi
+        <$> Api.deserialiseFromRawBytes Api.AsTxId bs
+
+  eix :: Either PlutusToCardanoError Word16
+  eix
+    | ix < 0 = Left $ UnknownPlutusToCardanoError $ Text.pack $ "txOutRefFromPlutus: negative txOutRefIdx " ++ show ix
+    | ix > toInteger (maxBound @Word) = Left $ UnknownPlutusToCardanoError $ Text.pack $ "txOutRefFromPlutus: txOutRefIdx " ++ show ix ++ " too large"
+    | otherwise = Right $ fromInteger ix
+
+govActionIdToPlutus :: GYGovActionId -> PlutusV3.GovernanceActionId
+govActionIdToPlutus (GYGovActionId tid ix) =
+  PlutusV3.GovernanceActionId
+    (PlutusV3.TxId . BuiltinByteString . Api.serialiseToRawBytes . txIdToApi $ tid)
+    (toInteger ix)
 
 -- | Voting procedure.
 data GYVotingProcedure = GYVotingProcedure

--- a/src/GeniusYield/Types/Script/ScriptHash.hs
+++ b/src/GeniusYield/Types/Script/ScriptHash.hs
@@ -93,8 +93,8 @@ apiHashFromPlutus (PlutusV1.ScriptHash (BuiltinByteString bs)) = Api.deserialise
 scriptHashToPlutus :: GYScriptHash -> PlutusV1.ScriptHash
 scriptHashToPlutus = scriptHashToApi >>> apiHashToPlutus
 
-scriptHashFromPlutus :: PlutusV1.ScriptHash -> Either Api.SerialiseAsRawBytesError GYScriptHash
-scriptHashFromPlutus sh = scriptHashFromApi <$> apiHashFromPlutus sh
+scriptHashFromPlutus :: PlutusV1.ScriptHash -> Either PlutusToCardanoError GYScriptHash
+scriptHashFromPlutus = validatorHashFromPlutus
 
 {-# DEPRECATED GYValidatorHash "Use GYScriptHash." #-}
 type GYValidatorHash = GYScriptHash

--- a/src/GeniusYield/Types/Script/ScriptHash.hs
+++ b/src/GeniusYield/Types/Script/ScriptHash.hs
@@ -11,7 +11,9 @@ module GeniusYield.Types.Script.ScriptHash (
   scriptHashToApi,
   scriptHashToLedger,
   scriptHashFromLedger,
+  apiHashFromPlutus,
   apiHashToPlutus,
+  scriptHashFromPlutus,
   scriptHashToPlutus,
   GYValidatorHash,
   validatorHashToPlutus,
@@ -33,6 +35,7 @@ import GeniusYield.Imports
 import GeniusYield.Types.Ledger (PlutusToCardanoError (..))
 import PlutusLedgerApi.V1 qualified as PlutusV1
 import PlutusTx.Builtins qualified as PlutusTx
+import PlutusTx.Builtins.Internal (BuiltinByteString (BuiltinByteString))
 import Text.Printf qualified as Printf
 import Web.HttpApiData qualified as Web
 
@@ -84,8 +87,14 @@ scriptHashFromLedger = Api.fromShelleyScriptHash >>> scriptHashFromApi
 apiHashToPlutus :: Api.ScriptHash -> PlutusV1.ScriptHash
 apiHashToPlutus h = PlutusV1.ScriptHash $ PlutusTx.toBuiltin $ Api.serialiseToRawBytes h
 
+apiHashFromPlutus :: PlutusV1.ScriptHash -> Either Api.SerialiseAsRawBytesError Api.ScriptHash
+apiHashFromPlutus (PlutusV1.ScriptHash (BuiltinByteString bs)) = Api.deserialiseFromRawBytes Api.AsScriptHash bs
+
 scriptHashToPlutus :: GYScriptHash -> PlutusV1.ScriptHash
 scriptHashToPlutus = scriptHashToApi >>> apiHashToPlutus
+
+scriptHashFromPlutus :: PlutusV1.ScriptHash -> Either Api.SerialiseAsRawBytesError GYScriptHash
+scriptHashFromPlutus sh = scriptHashFromApi <$> apiHashFromPlutus sh
 
 {-# DEPRECATED GYValidatorHash "Use GYScriptHash." #-}
 type GYValidatorHash = GYScriptHash

--- a/src/GeniusYield/Types/Slot.hs
+++ b/src/GeniusYield/Types/Slot.hs
@@ -36,7 +36,7 @@ import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
 -- Error "parsing Word64 failed, value is either floating or will cause over or underflow 4.2e29"
 newtype GYSlot = GYSlot Word64
   deriving (Show, Read, Eq, Ord)
-  deriving newtype (Swagger.ToParamSchema, Swagger.ToSchema, ToJSON, FromJSON, ToHttpApiData, FromHttpApiData, Num)
+  deriving newtype (Swagger.ToParamSchema, Swagger.ToSchema, ToJSON, FromJSON, ToHttpApiData, FromHttpApiData)
 
 instance Printf.PrintfArg GYSlot where
   formatArg (GYSlot n) = Printf.formatArg (show n)

--- a/src/GeniusYield/Types/Slot.hs
+++ b/src/GeniusYield/Types/Slot.hs
@@ -36,7 +36,7 @@ import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
 -- Error "parsing Word64 failed, value is either floating or will cause over or underflow 4.2e29"
 newtype GYSlot = GYSlot Word64
   deriving (Show, Read, Eq, Ord)
-  deriving newtype (Swagger.ToParamSchema, Swagger.ToSchema, ToJSON, FromJSON, ToHttpApiData, FromHttpApiData)
+  deriving newtype (Swagger.ToParamSchema, Swagger.ToSchema, ToJSON, FromJSON, ToHttpApiData, FromHttpApiData, Num)
 
 instance Printf.PrintfArg GYSlot where
   formatArg (GYSlot n) = Printf.formatArg (show n)


### PR DESCRIPTION
## Summary

Adding new utilities for Governance types and ScriptHashes to convert between different representations of the same type of (Plutus, ledger, api, etc.)

- GYGovActionId: from/to Plutus, Aeson
- GYVote: from/to Plutus, Aeson
- GYScriptHash: apiHashFromPlutus, scriptHashFromPlutus
- GYSlot: Number instance (to add the ability of arithmetics on GYSlot)

## Type of Change

Please mark the relevant option(s) for your pull request:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

Please ensure that your pull request meets the following criteria:

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's coding style and best practices
- [x] My code is appropriately commented and includes relevant documentation
- [ ] I have added tests to cover my changes
  (haven't found any tests for similar conversion functions, so I haven't added any, but I can add some roundtrip tests if required)
- [x] All new and existing tests pass
- [x] I have updated the documentation, if necessary

## Testing

As mentioned above, I haven't found any tests for similar conversion functions, so I haven't added any, but I can add some roundtrip tests if required.

