### PR TITLE
feat:  Add Custom Blockfrost URL Support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -46,6 +46,14 @@ source-repository-package
 package postgresql-libpq
   flags: +use-pkg-config
 
+source-repository-package
+  type: git
+  location: https://github.com/blockfrost/blockfrost-haskell
+  tag: client-0.11.0.0
+  subdir: blockfrost-client
+          blockfrost-client-core
+          blockfrost-api
+
 -- Temporary until latest version is available on Hackage (or CHaP for that matter). Track https://github.com/IntersectMBO/cardano-addresses/issues/294.
 source-repository-package
   type: git

--- a/src/GeniusYield/GYConfig.hs
+++ b/src/GeniusYield/GYConfig.hs
@@ -131,6 +131,7 @@ The supported providers. The options are:
 - Ogmios node instance along with Kupo
 - Maestro blockchain API, provided its API token.
 - Blockfrost API, provided its API key.
+- Custom Blockfrost instance, provided its URL and optional API key.
 
 In JSON format, this essentially corresponds to:
 
@@ -138,6 +139,7 @@ In JSON format, this essentially corresponds to:
 | { ogmiosUrl: string, kupoUrl: string, mempoolCache: { cacheInterval: number }, localTxSubmissionCache: { cacheInterval: number } }
 | { maestroToken: string, turboSubmit: boolean }
 | { blockfrostKey: string }
+| { blockfrostUrl: string, maybeBlockfrostKey: string? }
 
 The constructor tags don't need to appear in the JSON.
 -}

--- a/tests/GeniusYield/Test/Config.hs
+++ b/tests/GeniusYield/Test/Config.hs
@@ -17,6 +17,7 @@ configTests =
     [ testCase "core-local" $ testParseResult isNodeKupo "core-local.json"
     , testCase "core-maestro" $ testParseResult isMaestro "core-maestro.json"
     , testCase "core-blockfrost" $ testParseResult isBlockfrost "core-blockfrost.json"
+    , testCase "core-blockfrost-custom" $ testParseResult isBlockfrost "core-blockfrost-custom.json"
     ]
 
 testParseResult :: (GYCoreProviderInfo -> Bool) -> FilePath -> IO ()

--- a/tests/GeniusYield/Test/Providers/Mashup.hs
+++ b/tests/GeniusYield/Test/Providers/Mashup.hs
@@ -193,4 +193,5 @@ isProviderSupported :: GYCoreConfig -> Bool
 isProviderSupported (cfgCoreProvider -> cp) = case cp of
   GYCoreLayer1ProviderInfo GYMaestro {} -> False
   GYCoreLayer1ProviderInfo GYBlockfrost {} -> False
+  GYCoreLayer1ProviderInfo GYBlockfrostCustom {} -> False
   _anyOther -> True

--- a/tests/mock-configs/core-blockfrost-custom.json
+++ b/tests/mock-configs/core-blockfrost-custom.json
@@ -1,0 +1,4 @@
+{
+    "blockfrostUrl": "http://localhost:3000",
+    "maybeBlockfrostKey": "QED"
+}


### PR DESCRIPTION
## Summary

This PR adds support for custom Blockfrost URLs in Atlas, enabling the use of self-hosted or alternative Blockfrost instances. Previously, Atlas only supported the official Blockfrost environments (mainnet, preprod, preview). This change allows users to configure a custom Blockfrost URL and optionally provide an API key for authentication.

Closes #481

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's coding style and best practices
- [x] My code is appropriately commented and includes relevant documentation
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
- [x] I have updated the documentation, if necessary

## Testing

**Automated tests:**
- [x] Added configuration parsing test for `GYBlockfrostCustom` variant
- [x] Test verifies custom Blockfrost config is correctly parsed and identified
- [x] All existing tests pass, confirming backward compatibility
- [x] Custom Blockfrost provider properly filtered from mashup tests (like standard Blockfrost)

**Manual testing:**
- [x] Verified custom Blockfrost URL connects successfully to preprod instance
- [x] Tested with API key authentication (`maybeBlockfrostKey` with value)
- [x] Confirmed queries work correctly through custom URL endpoint
- [x] Validated backward compatibility with existing Blockfrost configurations

**Note:** Full provider integration tests require API credentials and are excluded from CI. The new `GYBlockfrostCustom` provider shares the same endpoint limitations as standard Blockfrost (governance, mempool operations) and is appropriately filtered from tests requiring those features.

## Additional Information

**Related Issue:** #481

**Changes made:**
- Added `GYBlockfrostCustom` variant to `GYLayer1ProviderInfo` data type with custom URL and optional API key
- Implemented `networkIdToProjectCustom` function to construct Blockfrost client with custom URL
- Updated `isBlockfrost` predicate to recognize the new custom variant
- Fixed error pattern matching for `BlockfrostNotFound` to handle the constructor's argument
- Added blockfrost-haskell dependencies in `cabal.project`, latest release.

**Use case:** This enables users to run Atlas against custom Blockfrost deployments, which is useful for private networks, testing environments, or alternative Blockfrost implementations.